### PR TITLE
feat: Win32 윈도우 창 생성을 위한 최소 프레임워크 구축

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,6 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+# vcpkg
+vcpkg_installed/

--- a/ProjectArenaDungeon/Main.cpp
+++ b/ProjectArenaDungeon/Main.cpp
@@ -1,0 +1,23 @@
+#include "pch.h"
+#include "Window.h"
+
+HWND gHandle = nullptr;
+float gWinWidth = WIN_DEFAULT_WIDTH;
+float gWinHeight = WIN_DEFAULT_HEIGHT;
+
+int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
+    _In_opt_ HINSTANCE hPrevInstance,
+    _In_ LPWSTR    lpCmdLine,
+    _In_ int       nCmdShow)
+{
+    WinDesc desc;
+    desc.appName = L"ArenaDungeon";
+    desc.instance = hInstance;
+    desc.width = gWinWidth;
+    desc.height = gWinHeight;
+
+    auto window = std::make_unique<Window>(desc);
+    WPARAM wParam = window->Run();
+
+    return (int)wParam;
+}

--- a/ProjectArenaDungeon/ProjectArenaDungeon.vcxproj
+++ b/ProjectArenaDungeon/ProjectArenaDungeon.vcxproj
@@ -124,6 +124,8 @@
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -146,6 +148,16 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="Main.cpp" />
+    <ClCompile Include="pch.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="Window.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="pch.h" />
+    <ClInclude Include="targetver.h" />
+    <ClInclude Include="Window.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/ProjectArenaDungeon/Window.cpp
+++ b/ProjectArenaDungeon/Window.cpp
@@ -1,0 +1,114 @@
+#include "pch.h"
+#include "Window.h"
+
+Window::Window(const WinDesc& initDesc)
+    :desc(initDesc)
+{
+    WORD wHr = MyRegisterClass(desc);
+    assert(wHr != 0);
+
+    gHandle = desc.handle = CreateWindowExW
+    (
+        WS_EX_APPWINDOW,
+        desc.appName.c_str(),
+        desc.appName.c_str(),
+        WS_OVERLAPPEDWINDOW,
+        CW_USEDEFAULT,
+        CW_USEDEFAULT,
+        CW_USEDEFAULT,
+        CW_USEDEFAULT,
+        nullptr,
+        HMENU(nullptr),
+        desc.instance,
+        nullptr
+    );
+
+    assert(desc.handle != nullptr);
+
+    RECT rect = { 0, 0, LONG(desc.width), LONG(desc.height) };
+
+    AdjustWindowRectEx(&rect, WS_OVERLAPPEDWINDOW, false, 0);
+
+    const long& winWidth = rect.right - rect.left;
+    const long& winHeight = rect.bottom - rect.top;
+
+    const UINT& winX = UINT((GetSystemMetrics(SM_CXSCREEN) - winWidth) * 0.5f);
+    const UINT& winY = UINT((GetSystemMetrics(SM_CYSCREEN) - winHeight) * 0.5f);
+
+    MoveWindow
+    (
+        desc.handle,
+        winX,
+        winY,
+        winWidth,
+        winHeight,
+        true
+    );
+
+    ShowWindow(desc.handle, SW_SHOWNORMAL);
+    UpdateWindow(desc.handle);
+
+    ShowCursor(true);
+}
+
+Window::~Window()
+{
+    UnregisterClassW(desc.appName.c_str(), desc.instance);
+}
+
+ATOM Window::MyRegisterClass(const WinDesc& initDesc)
+{
+    WNDCLASSEXW wcex = { 0 };
+
+    wcex.cbSize = sizeof(WNDCLASSEX);
+    wcex.style = CS_HREDRAW | CS_VREDRAW | CS_DBLCLKS;
+    wcex.lpfnWndProc = &WndProc;
+    wcex.cbClsExtra = 0;
+    wcex.cbWndExtra = 0;
+    wcex.hInstance = initDesc.instance;
+    wcex.hIcon = LoadIcon(nullptr, IDI_WINLOGO);
+    wcex.hCursor = LoadCursor(nullptr, IDC_ARROW);
+    wcex.hbrBackground = HBRUSH(GetStockObject(GRAY_BRUSH));
+    wcex.lpszMenuName = nullptr;
+    wcex.lpszClassName = initDesc.appName.c_str();
+    wcex.hIconSm = wcex.hIcon;
+
+    return RegisterClassExW(&wcex);
+}
+
+WPARAM Window::Run()
+{
+    MSG msg;
+
+    // 기본 메시지 루프입니다:
+    while (true)
+    {
+        if (PeekMessage(&msg, nullptr, 0, 0, PM_REMOVE))
+        {
+            if (msg.message == WM_QUIT)
+                break;
+
+            TranslateMessage(&msg);
+            DispatchMessage(&msg);
+        }
+        else
+        {
+            // Managers Update
+        }
+    }
+
+    return msg.wParam;
+}
+
+LRESULT Window::WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
+{
+    switch (message)
+    {
+    case WM_DESTROY:
+        PostQuitMessage(0);
+
+        return 0;
+    }
+
+    return DefWindowProc(hWnd, message, wParam, lParam);
+}

--- a/ProjectArenaDungeon/Window.h
+++ b/ProjectArenaDungeon/Window.h
@@ -1,0 +1,25 @@
+#pragma once
+struct WinDesc
+{
+	std::wstring appName = L"";
+	HINSTANCE instance = nullptr;
+	HWND handle = nullptr;
+	float width = 0;
+	float height = 0;
+};
+
+class Window
+{
+public:
+	Window(const WinDesc& initDesc);
+	~Window();
+
+	ATOM MyRegisterClass(const WinDesc& initDesc);
+
+	WPARAM Run();
+
+private:
+	static LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
+
+	WinDesc desc;
+};

--- a/ProjectArenaDungeon/pch.cpp
+++ b/ProjectArenaDungeon/pch.cpp
@@ -1,0 +1,1 @@
+#include "pch.h"

--- a/ProjectArenaDungeon/pch.h
+++ b/ProjectArenaDungeon/pch.h
@@ -1,0 +1,39 @@
+#pragma once
+#pragma once
+
+#define NOMINMAX
+
+#ifdef _DEBUG
+#pragma comment(linker, "/subsystem:console /entry:wWinMainCRTStartup")
+#endif
+
+#include "targetver.h"
+#define WIN32_LEAN_AND_MEAN
+
+// Windows header
+#include <windows.h>
+#include <windowsx.h>
+
+// C runtime header
+#include <cassert>
+
+// C++ runtime header
+#include <string>
+#include <memory>
+#include <iostream>
+
+// window runtime header
+#include <wrl.h>
+using Microsoft::WRL::ComPtr;
+
+// Extern Globals
+extern HWND gHandle;
+extern float gWinWidth;
+extern float gWinHeight;
+
+// constant expression
+constexpr float epsilon = 1e-5f;
+
+// window default size
+#define WIN_DEFAULT_WIDTH 1280
+#define WIN_DEFAULT_HEIGHT 720

--- a/ProjectArenaDungeon/targetver.h
+++ b/ProjectArenaDungeon/targetver.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#include <SDKDDKVer.h>

--- a/ProjectArenaDungeon/vcpkg.json
+++ b/ProjectArenaDungeon/vcpkg.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+  "name": "arenadungeon",
+  "version": "0.0.1",
+  "dependencies": [
+    {
+      "name": "directxtex",
+      "features": [ "dx11" ]
+    },
+    "box2d"
+  ]
+}


### PR DESCRIPTION
## Overview
Win32 기반의 기본 윈도우 프레임워크 구현하고, 프로젝트의 초기 개발 환경을 설정

---

## Changes
- WinMain 진입점 설정
- WinDesc 구조체를 통한 
- Window 클래스 구현
  - MyRegisterClass를 통한 클래스 등록
  - 기본 메시지 루프 구성
- 미리 컴파일된 헤더 작성 및 설정
  - Windows 플랫폼 버전 정의와 헤더 최적화 설정
  - C/C++ 표준 라이브러리 및 Windows 헤더 포함
  - Microsoft WRL ComPtr 정의
  - 전역 변수 선언 (HWND 핸들, 창의 가로, 세로 크기)
  - 상수 표현식을 통한 epsilon 정의
  - 기본 창 크기를 1280x720 으로 설정

---

## Purpose
- 애플리케이션의 기본 실행 구조 구현
- 렌더링 및 엔진 시스템 확장을 위한 기반 생성
- 미리 컴파일 된 헤더를 통한 빌드 최적화
- vcpkg manifest를 기반으로 한 관리 구조 설정

---

## How to Test
1. 디버그 모드로 프로젝트 빌드
2. 실행 결과 확인
  - 1280x720 크기의 창 생성
  - 콘솔창 생성 (디버그 모드)
  - 창 닫기로 정상 종료

---

## Notes

Related to #3 