### PR TITLE
feat: ShaderManager 및 셰이더 래퍼 클래스 구현

### DIFF
--- a/ProjectArenaDungeon/Managers/ShaderManager.cpp
+++ b/ProjectArenaDungeon/Managers/ShaderManager.cpp
@@ -1,26 +1,34 @@
 #include "pch.h"
 #include "ShaderManager.h"
 
+#include "Renders/IA/InputLayout.h"
+
 ShaderManager::ShaderManager() {}
 
 ShaderSet ShaderManager::GetShader(const std::wstring& path, std::span<const D3D11_INPUT_ELEMENT_DESC> descs)
 {
+	// path를 기준으로 캐시 조회
 	auto it = shaderCache.find(path);
 
 	if (it != shaderCache.end())
 		return it->second;
 
+	// 새 ShaderSet 생성
 	ShaderSet newSet;
 
+	// VertexShader 생성
 	newSet.vs = std::make_shared<VertexShader>();
 	newSet.vs->Create(path, "VS");
 
+	// InputLayout 생성
 	newSet.il = std::make_shared<InputLayout>();
 	newSet.il->Create(descs, newSet.vs->GetBlob());
 
+	// PixelShader 생성
 	newSet.ps = std::make_shared<PixelShader>();
 	newSet.ps->Create(path, "PS");
 
+	// 캐시에 저장
 	shaderCache.emplace(path, newSet);
 
 	return newSet;

--- a/ProjectArenaDungeon/Managers/ShaderManager.cpp
+++ b/ProjectArenaDungeon/Managers/ShaderManager.cpp
@@ -1,0 +1,27 @@
+#include "pch.h"
+#include "ShaderManager.h"
+
+ShaderManager::ShaderManager() {}
+
+ShaderSet ShaderManager::GetShader(const std::wstring& path, std::span<const D3D11_INPUT_ELEMENT_DESC> descs)
+{
+	auto it = shaderCache.find(path);
+
+	if (it != shaderCache.end())
+		return it->second;
+
+	ShaderSet newSet;
+
+	newSet.vs = std::make_shared<VertexShader>();
+	newSet.vs->Create(path, "VS");
+
+	newSet.il = std::make_shared<InputLayout>();
+	newSet.il->Create(descs, newSet.vs->GetBlob());
+
+	newSet.ps = std::make_shared<PixelShader>();
+	newSet.ps->Create(path, "PS");
+
+	shaderCache.emplace(path, newSet);
+
+	return newSet;
+}

--- a/ProjectArenaDungeon/Managers/ShaderManager.cpp
+++ b/ProjectArenaDungeon/Managers/ShaderManager.cpp
@@ -2,6 +2,8 @@
 #include "ShaderManager.h"
 
 #include "Renders/IA/InputLayout.h"
+#include "Renders/Shaders/VertexShader.h"
+#include "Renders/Shaders/PixelShader.h"
 
 ShaderManager::ShaderManager() {}
 

--- a/ProjectArenaDungeon/Managers/ShaderManager.h
+++ b/ProjectArenaDungeon/Managers/ShaderManager.h
@@ -15,14 +15,21 @@ struct ShaderSet
 
 // ShaderManager
 // - 셰이더 로딩/생성 캐싱을 담당하는 매니저
+// - 동일 path에 대해 재생성을 방지
 
 class ShaderManager
 {
 	DECLARE_SINGLETON(ShaderManager)
 
 public:
+	// GetShader
+	// - path와 입력 레이아웃을 기반으로 ShaderSet을 반환
+	// - 캐시에 존재하면 해당 리소스를 반환, 없다면 생성 후 캐시에 저장
 	ShaderSet GetShader(const std::wstring& path, std::span<const D3D11_INPUT_ELEMENT_DESC> descs);
 
 private:
+	// Shader cache
+	// - key: shader file path
+	// - value: ShaderSet
 	std::unordered_map<std::wstring, ShaderSet> shaderCache;
 };

--- a/ProjectArenaDungeon/Managers/ShaderManager.h
+++ b/ProjectArenaDungeon/Managers/ShaderManager.h
@@ -1,0 +1,28 @@
+#pragma once
+class InputLayout;
+class VertexShader;
+class PixelShader;
+
+// ShaderSet
+// - HLSL파일(path 기준)에서 사용하는 리소스 묶음
+// - InputLayout, VertexShader, PixelShader를 함께 보관
+struct ShaderSet
+{
+	std::shared_ptr<InputLayout> il;
+	std::shared_ptr<VertexShader> vs;
+	std::shared_ptr<PixelShader> ps;
+};
+
+// ShaderManager
+// - 셰이더 로딩/생성 캐싱을 담당하는 매니저
+
+class ShaderManager
+{
+	DECLARE_SINGLETON(ShaderManager)
+
+public:
+	ShaderSet GetShader(const std::wstring& path, std::span<const D3D11_INPUT_ELEMENT_DESC> descs);
+
+private:
+	std::unordered_map<std::wstring, ShaderSet> shaderCache;
+};

--- a/ProjectArenaDungeon/ProjectArenaDungeon.vcxproj
+++ b/ProjectArenaDungeon/ProjectArenaDungeon.vcxproj
@@ -160,6 +160,9 @@
     <ClCompile Include="Renders\IA\IndexBuffer.cpp" />
     <ClCompile Include="Renders\IA\InputLayout.cpp" />
     <ClCompile Include="Renders\IA\VertexBuffer.cpp" />
+    <ClCompile Include="Renders\Shaders\PixelShader.cpp" />
+    <ClCompile Include="Renders\Shaders\Shader.cpp" />
+    <ClCompile Include="Renders\Shaders\VertexShader.cpp" />
     <ClCompile Include="Window.cpp" />
   </ItemGroup>
   <ItemGroup>
@@ -173,6 +176,9 @@
     <ClInclude Include="Renders\IA\IndexBuffer.h" />
     <ClInclude Include="Renders\IA\InputLayout.h" />
     <ClInclude Include="Renders\IA\VertexBuffer.h" />
+    <ClInclude Include="Renders\Shaders\PixelShader.h" />
+    <ClInclude Include="Renders\Shaders\Shader.h" />
+    <ClInclude Include="Renders\Shaders\VertexShader.h" />
     <ClInclude Include="targetver.h" />
     <ClInclude Include="Window.h" />
   </ItemGroup>

--- a/ProjectArenaDungeon/ProjectArenaDungeon.vcxproj
+++ b/ProjectArenaDungeon/ProjectArenaDungeon.vcxproj
@@ -152,6 +152,7 @@
     <ClCompile Include="Main.cpp" />
     <ClCompile Include="Managers\GraphicsManager.cpp" />
     <ClCompile Include="Managers\InputManager.cpp" />
+    <ClCompile Include="Managers\ShaderManager.cpp" />
     <ClCompile Include="Managers\TimeManager.cpp" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
@@ -164,6 +165,7 @@
   <ItemGroup>
     <ClInclude Include="Managers\GraphicsManager.h" />
     <ClInclude Include="Managers\InputManager.h" />
+    <ClInclude Include="Managers\ShaderManager.h" />
     <ClInclude Include="Managers\TimeManager.h" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="Renders\ConstantBuffers\ConstantBuffer.h" />

--- a/ProjectArenaDungeon/Renders/Shaders/PixelShader.cpp
+++ b/ProjectArenaDungeon/Renders/Shaders/PixelShader.cpp
@@ -1,0 +1,33 @@
+#include "pch.h"
+#include "PixelShader.h"
+
+void PixelShader::Create(const std::wstring& path, const std::string& entryName)
+{
+	this->path = path;
+	this->entryName = entryName;
+
+	// HLSL 컴파일 (ps_5_0)
+	CompileShader(this->path, this->entryName, "ps_5_0", &blob);
+
+	// 리소스 생성
+	HRESULT hr = DEVICE->CreatePixelShader(
+		blob->GetBufferPointer(),
+		blob->GetBufferSize(),
+		nullptr,
+		&shader
+	);
+	CHECK(hr);
+}
+
+void PixelShader::Clear()
+{
+	// 리소스 해제
+	shader.Reset();
+	blob.Reset();
+}
+
+void PixelShader::Bind()
+{
+	// PS 단계에 바인딩
+	DEVICE_CONTEXT->PSSetShader(shader.Get(), nullptr, 0);
+}

--- a/ProjectArenaDungeon/Renders/Shaders/PixelShader.h
+++ b/ProjectArenaDungeon/Renders/Shaders/PixelShader.h
@@ -1,0 +1,29 @@
+#pragma once
+#include "pch.h"
+#include "Shader.h"
+
+// PixelShader
+// - HLSL Pixel Shader를 컴파일하고 PixelShader 리소스를 생성하는 클래스
+class PixelShader : public Shader
+{
+public:
+	// Create
+	// - HLSL 파일 경로와 entryName을 기준으로 컴파일하고 리소스를 생성
+	void Create(const std::wstring& path, const std::string& entryName) override;
+
+	// Clear
+	// - 리소스 및 컴파일 결과(blob)를 해제
+	void Clear() override;
+
+	// Bind
+	// - 렌더링 파이프라인(PS 단계)에 PixelShader를 바인딩
+	void Bind() override;
+
+	// GetResource
+	// - 생성된 ID3D11PixelShader 리소스를 반환
+	ID3D11PixelShader* GetResource() const { return shader.Get(); }
+
+private:
+	ComPtr<ID3DBlob> blob;				// 컴파일된 바이트코드
+	ComPtr<ID3D11PixelShader> shader;	// PixelShader 리소스
+};

--- a/ProjectArenaDungeon/Renders/Shaders/Shader.cpp
+++ b/ProjectArenaDungeon/Renders/Shaders/Shader.cpp
@@ -1,0 +1,36 @@
+#include "pch.h"
+#include "Shader.h"
+
+void Shader::CompileShader(const std::wstring& path, const std::string& entryName, const std::string& profile, ID3DBlob** blob)
+{
+	ComPtr<ID3DBlob> error;
+	
+	HRESULT hr = D3DCompileFromFile
+	(
+		path.c_str(),
+		nullptr,
+		nullptr,
+		entryName.c_str(),
+		profile.c_str(),
+		D3DCOMPILE_ENABLE_STRICTNESS,
+		0,
+		blob,
+		&error
+	);
+	CheckShaderError(hr, error);
+}
+
+void Shader::CheckShaderError(HRESULT hr, const ComPtr<ID3DBlob>& error)
+{
+	// shader error 발생 시 메시지 박스를 통해 에러 메시지 출력
+	if (FAILED(hr))
+	{
+		if (error.Get())
+		{
+			const std::string& str = static_cast<const char*>(error->GetBufferPointer());
+			// 메시지 박스 팝업 출력
+			MessageBoxA(nullptr, str.c_str(), "Shader Error", MB_OK);
+		}
+		assert(false && "Shader compilation failed");
+	}
+}

--- a/ProjectArenaDungeon/Renders/Shaders/Shader.h
+++ b/ProjectArenaDungeon/Renders/Shaders/Shader.h
@@ -1,0 +1,37 @@
+#pragma once
+
+// Shader
+// - 셰이더 기반 클래스
+// - 파생 클래스(VertexShader / PixelShader)에서 실제 리소스 생성(Create) 및 바인딩(Bind)을 구현
+// - CompileShader()를 통해 HLSL을 컴파일
+class Shader
+{
+public:
+
+	// Create
+	// - path의 HLSL 파일을 entryName기준으로 컴파일하고,
+	//   파생 클래스에서 리소스(VertexShader, PixelShader 등)를 생성
+	virtual void Create(const std::wstring& path, const std::string& entryName) = 0;
+
+	// Clear
+	// - 보유한 리소스를 해제
+	virtual void Clear() = 0;
+
+	// Bind
+	// - 렌더링 파이프라인에 셰이더를 바인딩
+	virtual void Bind() = 0;
+
+protected:
+	// CompileShader
+	// - HLSL 파일(path)을 컴파일하여 blob 생성
+	void CompileShader(const std::wstring& path, const std::string& entryName, const std::string& profile, ID3DBlob** blob);
+
+private:
+	// CheckShaderError
+	// - 컴파일 실패 시 메시지 박스를 통해 에러 메시지를 출력
+	void CheckShaderError(HRESULT hr, const ComPtr<ID3DBlob>& error);
+
+protected:
+	std::wstring path = L"";
+	std::string entryName = "";
+};

--- a/ProjectArenaDungeon/Renders/Shaders/VertexShader.cpp
+++ b/ProjectArenaDungeon/Renders/Shaders/VertexShader.cpp
@@ -1,0 +1,33 @@
+#include "pch.h"
+#include "VertexShader.h"
+
+void VertexShader::Create(const std::wstring& path, const std::string& entryName)
+{
+	this->path = path;
+	this->entryName = entryName;
+
+	// HLSL 컴파일 (vs_5_0)
+	CompileShader(this->path, this->entryName, "vs_5_0", &blob);
+	
+	// 리소스 생성
+	HRESULT hr = DEVICE->CreateVertexShader(
+		blob->GetBufferPointer(),
+		blob->GetBufferSize(),
+		nullptr,
+		&shader
+	);
+	CHECK(hr);
+}
+
+void VertexShader::Clear()
+{
+	// 리소스 해제
+	shader.Reset();
+	blob.Reset();
+}
+
+void VertexShader::Bind()
+{
+	// VS 단계에 바인딩
+	DEVICE_CONTEXT->VSSetShader(shader.Get(), nullptr, 0);
+}

--- a/ProjectArenaDungeon/Renders/Shaders/VertexShader.h
+++ b/ProjectArenaDungeon/Renders/Shaders/VertexShader.h
@@ -1,0 +1,34 @@
+#pragma once
+#include "pch.h"
+#include "Shader.h"
+
+// VertexShader
+// - HLSL Vertex Shader를 컴파일하고 Vertex Shader 리소스를 생성하는 클래스
+// - InputLayout 생성 시 필요한 바이트코드(blob)를 보관
+class VertexShader : public Shader
+{
+public:
+	// Create
+	// - HLSL 파일 경로와 entryName을 기준으로 컴파일하고 리소스를 생성
+	void Create(const std::wstring& path, const std::string& entryName) override;
+
+	// Clear
+	// - 리소스 및 컴파일 결과(blob)를 해제
+	void Clear() override;
+
+	// Bind
+	// - 렌더링 파이프라인(VS 단계)에 VertexShader를 바인딩
+	void Bind() override;
+
+	// GetBlob
+	// - 컴파일된 바이트코드를 반환
+	ID3DBlob* GetBlob() const { return blob.Get(); }
+
+	// GetResource
+	// - 생성된 ID3D11VertexShader 리소스를 반환
+	ID3D11VertexShader* GetResource() const { return shader.Get(); }
+
+private:
+	ComPtr<ID3DBlob> blob;				// 컴파일된 바이트코드
+	ComPtr<ID3D11VertexShader> shader;	// VertexShader 리소스
+};

--- a/ProjectArenaDungeon/_Shaders/VertexTexture.hlsl
+++ b/ProjectArenaDungeon/_Shaders/VertexTexture.hlsl
@@ -1,0 +1,64 @@
+#pragma pack_matrix(row_major)
+
+struct VertexInput
+{
+    float4 position : POSITION;
+    float2 uv : TEXCOORD;
+};
+
+struct PixelInput
+{
+    float4 position : SV_POSITION;
+    float2 uv : TEXCOORD;
+};
+
+cbuffer World : register(b0)
+{
+    matrix _world;
+}
+
+cbuffer ViewPorjection : register(b1)
+{
+    matrix _view;
+    matrix _proj;
+}
+
+cbuffer FrameBuffer : register(b10)
+{
+    float2 _startUV;
+    float2 _sizeUV;
+}
+
+PixelInput VS(VertexInput input)
+{
+    PixelInput output;
+    
+    // Transpose 정책에 따라 mul 순서 바뀔 수 있음
+    output.position = mul(input.position, _world);
+    output.position = mul(output.position, _view);
+    output.position = mul(output.position, _proj);
+
+    // Atlas frame
+    output.uv = _startUV + (input.uv * _sizeUV);
+
+    return output;
+}
+
+cbuffer Color : register(b2)
+{
+    float4 _color;
+}
+
+SamplerState samp : register(s0);   // 0~16
+Texture2D srcTex : register(t0);    // 0~128
+
+float4 PS(PixelInput input) : SV_Target0
+{
+    float4 texColor = srcTex.Sample(samp, input.uv);
+    
+    // MAGENTA 컬러 키 처리
+    if (texColor.r == 1.0f && texColor.g == 0.0f && texColor.b == 1.0f)
+        discard;
+    
+    return texColor * _color;
+}

--- a/ProjectArenaDungeon/pch.h
+++ b/ProjectArenaDungeon/pch.h
@@ -29,6 +29,7 @@
 #include <array>
 #include <vector>
 #include <span>
+#include <unordered_map>
 
 // DirectX D3D11
 #include <d3d11.h>


### PR DESCRIPTION
## Overview

렌더링 파이프라인의 Shader 단계의 기반 구조 구성 및 기본 HLSL 셰이더 추가

---

## Changes
- ShaderManager 구현
  - InputLayout / VertexShader / PixelShader를 ShaderSet으로 묶어 관리
  - HLSL 파일 경로(path)를 기준(키 값)으로 한 ShaderSet 캐싱
  - 동일 키에 대해 셰이더 재생성 방지
- Shader 래퍼 클래스 구현
  - Shader 기반 클래스 추가
  - VertexShader / PixelShader 파생 클래스 구현 (Create/Clear/Bind)
- 기본 HLSL 셰이더 추가
  - World / ViewProjection / Color / Frame 데이터 별 상수 버퍼 적용
  - UV 기반 스프라이트 처리
  - 텍스처 샘플링 + Color 곱을 통한 단색/텍스처 겸용 구조

---

## Purpose
- 렌더링 파이프라인의 Shader 단계 기반 구조 구축
- 이후 Mesh / Material / Texture 리소스 계층 구현을 위한 셰이더 기반 마련
- 테스트 씬을 진행하기 위한 최소 셰이더 환경 구성

---

## How to Test
1. 디버그 모드로 빌드
2. 추가한 파일(ShaderManager / Shader 래퍼 클래스)의 컴파일 에러 여부 확인
3. HLSL 컴파일 에러 여부 확인 (실제 드로우 테스트는 이후 PR에서 진행 예정)

---

## Notes
- ShaderSet 캐시 키는 현재 HLSL 경로(path) 기준으로 구성되어 있음
- VertexType 확장 시 InputLayout 캐시 키 정책 확장이 필요할 수 있음
- 본 PR은 셰이더 기반 구조 구축이 목적이며, 실제 드로우 테스트는 다음 PR에서 진행 예정