### PR TITLE
feat: GameInstance/Scene 구조 및 Object-Component 기반 구축

### DIFF
--- a/ProjectArenaDungeon/Components/Component.h
+++ b/ProjectArenaDungeon/Components/Component.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <string>
+#include <utility>
+
+class Object;
+class Collider;
+
+// Component
+// - Object에 결합되는 기능 단위의 기반 클래스
+// - Awake/Update/Render 와 충돌 이벤트 콜백을 제공
+class Component
+{
+public:
+	explicit Component(std::string compName);
+	virtual ~Component() = default;
+
+	// Awake
+	// - 오브젝트가 씬에 배치되거나 활성화될 때 초기화 용도로 호출
+	virtual void Awake() {}
+
+	// Update
+	// - 매 프레임 호출되는 갱신 함수
+	virtual void Update() {}
+
+	// Render
+	// - 매 프레임 렌더링 호출
+	virtual void Render() {}
+
+	// OnCollisionEnter
+	// - 충돌 시작 시점 콜백
+	// - 충돌 반응이 필요한 컴포넌트만 override 해서 사용
+	virtual void OnCollisionEnter(Collider* other) {}
+
+	// OnCollisionExit
+	// - 충돌 종료 시점 콜백
+	// - 충돌 반응이 필요한 컴포넌트만 override 해서 사용
+	virtual void OnCollisionExit(Collider* other) {}
+
+	// GetName
+	// - 컴포넌트 식별용 이름 반환
+	const std::string& GetName() const { return name; }
+
+	// GetOwner
+	// - 소유 오브젝트 반환
+	Object* GetOwner() const { return owner; }
+
+	// SetOwner
+	// - 소유 오브젝트를 설정한다
+	// - 일반적으로 Object::AddComponent에서만 호출되는 것을 전제로 한다
+	void SetOwner(Object* obj) { owner = obj; }
+
+protected:
+	std::string name;
+	Object* owner = nullptr;
+};

--- a/ProjectArenaDungeon/Components/Components.cpp
+++ b/ProjectArenaDungeon/Components/Components.cpp
@@ -1,0 +1,7 @@
+#include "pch.h"
+#include "Component.h"
+
+Component::Component(std::string compName)
+	: name(std::move(compName))
+{
+}

--- a/ProjectArenaDungeon/Components/Transform.cpp
+++ b/ProjectArenaDungeon/Components/Transform.cpp
@@ -1,0 +1,123 @@
+#include "pch.h"
+#include "Components/Transform.h"
+
+#include "Renders/ConstantBuffers/GlobalBuffers.h"
+
+using Vector2 = DirectX::SimpleMath::Vector2;
+using Matrix = DirectX::SimpleMath::Matrix;
+
+constexpr float epsilonSq = epsilon * epsilon;
+
+Transform::Transform(std::string name)
+	: Component(std::move(name))
+{
+	wb = std::make_unique<WorldBuffer>();
+}
+
+Transform::~Transform() = default;
+
+float Transform::GetRotationDegree() const
+{
+	return DirectX::XMConvertToDegrees(rotation);
+}
+
+void Transform::SetPosition(const Vector2& pos)
+{
+	if (position != pos)
+	{
+		position = pos;
+		bDirty = true;
+	}
+}
+
+void Transform::SetScale(const Vector2& s)
+{
+	if (scale != s)
+	{
+		scale = s;
+		bDirty = true;
+	}
+}
+
+void Transform::SetRotationDegree(float degree)
+{
+	const float radian = DirectX::XMConvertToRadians(degree);
+	SetRotationRadian(radian);
+}
+
+void Transform::SetRotationRadian(float radian)
+{
+	if (rotation != radian)
+	{
+		rotation = radian;
+		bDirty = true;
+	}
+}
+
+void Transform::Move(const Vector2& value)
+{
+	if (value.LengthSquared() < epsilonSq)
+		return;
+
+	position += value;
+	bDirty = true;
+}
+
+void Transform::AddScale(const Vector2& value)
+{
+	if (value.LengthSquared() < epsilonSq)
+		return;
+
+	scale += value;
+	bDirty = true;
+}
+
+void Transform::RotateDegree(float degree)
+{
+	if (std::abs(degree) < epsilon)
+		return;
+
+	rotation += DirectX::XMConvertToRadians(degree);
+	bDirty = true;
+}
+
+void Transform::RotateRadian(float radian)
+{
+	if (std::abs(radian) < epsilon)
+		return;
+
+	rotation += radian;
+	bDirty = true;
+}
+
+void Transform::Update()
+{
+	if (!bDirty)
+		return;
+
+	// NOTE: 화면 좌표계/회전 방향 정책에 맞춰 Z 회전 부호 변경
+	Matrix S = DirectX::XMMatrixScalingFromVector(scale);
+	Matrix R = DirectX::XMMatrixRotationZ(-rotation);
+	Matrix T = DirectX::XMMatrixTranslationFromVector(position);
+
+	// NOTE: 회전이 갱신되는 시점에만 로컬 축 벡터를 캐싱
+	float sinV = 0.0f;
+	float cosV = 0.0f;
+	DirectX::XMScalarSinCos(&sinV, &cosV, -rotation);
+
+	right = Vector2(cosV, sinV);
+	up = Vector2(-sinV, cosV);
+
+	world = S * R * T;
+
+	wb->SetWorldMatrix(world);
+	wb->Update();
+
+	bDirty = false;
+}
+
+void Transform::Render()
+{
+	// NOTE: 월드 버퍼는 기본 VS 슬롯 0을 사용
+	wb->BindVS(0);
+}

--- a/ProjectArenaDungeon/Components/Transform.h
+++ b/ProjectArenaDungeon/Components/Transform.h
@@ -1,0 +1,82 @@
+#pragma once
+
+#include "Components/Component.h"
+
+#include <memory>
+#include <cmath>
+
+// DirectXTK SimpleMath
+#include "_Libraries/DirectXTK/SimpleMath.h"
+
+class WorldBuffer;
+
+// Transform
+// - 오브젝트의 위치/회전/스케일을 보관하고, 월드 행렬을 계산
+// - 변경이 있을 때만 갱신하도록 dirty 플래그 기반으로 업데이트
+class Transform : public Component
+{
+public:
+	explicit Transform(std::string name = "Transform");
+	~Transform() override;
+
+	// Update
+	// - position/scale/rotation 변경 시 월드 행렬과 right/up 벡터를 갱신
+	// - 상수버퍼(WorldBuffer) 갱신은 dirty일 때만 수행
+	void Update() override;
+
+	// Render
+	// - 월드 행렬 상수버퍼를 VS에 바인딩
+	void Render() override;
+
+	// GetRight / GetUp
+	// - 현재 회전 기준의 로컬 축 벡터를 반환
+	DirectX::SimpleMath::Vector2 GetRight() const { return right; }
+	DirectX::SimpleMath::Vector2 GetUp() const { return up; }
+
+	DirectX::SimpleMath::Vector2 GetPosition() const { return position; }
+	DirectX::SimpleMath::Vector2 GetScale() const { return scale; }
+	float GetRotationRadian() const { return rotation; }
+	float GetRotationDegree() const;
+
+	// SetPosition
+	// - 위치를 설정하고, 값이 변경된 경우에만 dirty 처리
+	void SetPosition(const DirectX::SimpleMath::Vector2& pos);
+
+	// SetScale
+	// - 스케일을 설정하고, 값이 변경된 경우에만 dirty 처리
+	void SetScale(const DirectX::SimpleMath::Vector2& s);
+
+	// SetRotationDegree
+	// - 각도를 degree로 받아 radian으로 저장
+	void SetRotationDegree(float degree);
+
+	// SetRotationRadian
+	// - 회전을 radian으로 설정
+	void SetRotationRadian(float radian);
+
+	// Move
+	// - 위치를 누적 이동
+	void Move(const DirectX::SimpleMath::Vector2& value);
+
+	// AddScale
+	// - 스케일을 누적 변경
+	void AddScale(const DirectX::SimpleMath::Vector2& value);
+
+	// RotateDegree / RotateRadian
+	// - 회전을 누적 변경
+	void RotateDegree(float degree);
+	void RotateRadian(float radian);
+
+private:
+	DirectX::SimpleMath::Vector2 right = DirectX::SimpleMath::Vector2(1.0f, 0.0f);
+	DirectX::SimpleMath::Vector2 up = DirectX::SimpleMath::Vector2(0.0f, 1.0f);
+
+	DirectX::SimpleMath::Vector2 position = DirectX::SimpleMath::Vector2(0.0f, 0.0f);
+	DirectX::SimpleMath::Vector2 scale = DirectX::SimpleMath::Vector2(1.0f, 1.0f);
+	float rotation = 0.0f;
+
+	DirectX::SimpleMath::Matrix world = DirectX::SimpleMath::Matrix::Identity;
+	std::unique_ptr<WorldBuffer> wb;
+
+	bool bDirty = true;
+};

--- a/ProjectArenaDungeon/Components/Transform.h
+++ b/ProjectArenaDungeon/Components/Transform.h
@@ -75,7 +75,7 @@ private:
 	DirectX::SimpleMath::Vector2 scale = DirectX::SimpleMath::Vector2(1.0f, 1.0f);
 	float rotation = 0.0f;
 
-	DirectX::SimpleMath::Matrix world = DirectX::SimpleMath::Matrix::Identity;
+	DirectX::SimpleMath::Matrix world;
 	std::unique_ptr<WorldBuffer> wb;
 
 	bool bDirty = true;

--- a/ProjectArenaDungeon/GameInstance.cpp
+++ b/ProjectArenaDungeon/GameInstance.cpp
@@ -2,9 +2,7 @@
 #include "GameInstance.h"
 
 // Scenes
-#include "Scenes/Scene.h"
-// TODO: 테스트 씬 클래스가 생기면 include
-// #include "Scenes/TestScene.h"
+#include "Scenes/SceneList.h"
 
 GameInstance::GameInstance() {}
 
@@ -22,8 +20,9 @@ void GameInstance::Init()
 	// TODO: 전역 유틸 초기화
 	// Random::Init();
 
-	// TODO: 테스트 씬
-	// sceneList.push_back(std::make_shared<TestScene>());
+	// 씬 추가
+	//sceneList.push_back(std::make_shared<Loadout>());
+	sceneList.push_back(std::make_shared<Scene_TestFeature>());
 
 	if (!sceneList.empty())
 	{
@@ -40,7 +39,6 @@ void GameInstance::Update()
 	// - 디버그: 강제로 다시 로드 (Destroy -> Init)
 	if (INPUT.GetKeyPress(VK_F1)) RequestSceneChange(0, false);
 	if (INPUT.GetKeyPress(VK_F2)) RequestSceneChange(1, false);
-	if (INPUT.GetKeyPress(VK_F3)) RequestSceneChange(2, false);
 	// 강제 재시작 예시
 	//if (INPUT.GetKeyPress(VK_F5)) RequestSceneChange(currentSceneIndex, true);
 

--- a/ProjectArenaDungeon/GameInstance.cpp
+++ b/ProjectArenaDungeon/GameInstance.cpp
@@ -1,0 +1,106 @@
+#include "pch.h"
+#include "GameInstance.h"
+
+// Scenes
+#include "Scenes/Scene.h"
+// TODO: 테스트 씬 클래스가 생기면 include
+// #include "Scenes/TestScene.h"
+
+GameInstance::GameInstance() {}
+
+GameInstance::~GameInstance()
+{
+	// NOTE:
+	// - 씬이 해제되는 과정에서 다른 시스템(물리/리소스 등)을 참조할 수 있으므로
+	//   해제 순서가 중요한 시스템이 생기면 여기에서 순서를 명확하게 정리
+	currentScene = nullptr;
+	sceneList.clear();
+}
+
+void GameInstance::Init()
+{
+	// TODO: 전역 유틸 초기화
+	// Random::Init();
+
+	// TODO: 테스트 씬
+	// sceneList.push_back(std::make_shared<TestScene>());
+
+	if (!sceneList.empty())
+	{
+		currentSceneIndex = 0;
+		currentScene = sceneList[currentSceneIndex];
+		currentScene->Init();
+	}
+}
+
+void GameInstance::Update()
+{
+	// 테스트 전용 입력 기반 씬 전환
+	// - 기본: 동일 씬 무시
+	// - 디버그: 강제로 다시 로드 (Destroy -> Init)
+	if (INPUT.GetKeyPress(VK_F1)) RequestSceneChange(0, false);
+	if (INPUT.GetKeyPress(VK_F2)) RequestSceneChange(1, false);
+	if (INPUT.GetKeyPress(VK_F3)) RequestSceneChange(2, false);
+	// 강제 재시작 예시
+	//if (INPUT.GetKeyPress(VK_F5)) RequestSceneChange(currentSceneIndex, true);
+
+	if (currentScene)
+		currentScene->Update();
+
+	ApplySceneChange();
+}
+
+void GameInstance::Render()
+{
+	if (currentScene)
+		currentScene->Render();
+}
+
+void GameInstance::RequestSceneChange(size_t index, bool bForceReload)
+{
+	if (index >= sceneList.size())
+		return;
+
+	// NOTE:
+	// - 기본 정책: 동일 씬이면 무시
+	// - 디버그/테스트 목적: 강제 재로드 요청 시 동일 씬도 허용
+	if (!bForceReload && currentSceneIndex == index)
+		return;
+
+	pendingSceneIndex = index;
+	pendingForceReload = bForceReload;
+}
+
+void GameInstance::ApplySceneChange()
+{
+	if (pendingSceneIndex == npos)
+		return;
+
+	// Apply 시점에서 최종 정책 재확인
+	if (!pendingForceReload && currentSceneIndex == pendingSceneIndex)
+	{
+		pendingSceneIndex = npos;
+		pendingForceReload = false;
+		return;
+	}
+
+	// 기존 씬 정리
+	if (currentScene)
+	{
+		currentScene->Destroy();
+	}
+
+	// 씬 교체
+	currentSceneIndex = pendingSceneIndex;
+	currentScene = sceneList[currentSceneIndex];
+
+	// 요청 상태 리셋
+	pendingSceneIndex = npos;
+	pendingForceReload = false;
+
+	// 새 씬 초기화
+	if (currentScene)
+	{
+		currentScene->Init();
+	}
+}

--- a/ProjectArenaDungeon/GameInstance.h
+++ b/ProjectArenaDungeon/GameInstance.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <memory>
+#include <vector>
+#include <cstddef>
+
 class Scene;
 
 // GameInstance

--- a/ProjectArenaDungeon/GameInstance.h
+++ b/ProjectArenaDungeon/GameInstance.h
@@ -1,0 +1,60 @@
+#pragma once
+
+class Scene;
+
+// GameInstance
+// - 프로그램 실행 동안 유지되는 최상위 게임 컨텍스트
+// - Scene의 생성/소유/전환을 관리하고 Update/Render 호출을 연결
+//
+// NOTE:
+// - 현재는 테스트 씬 1개를 기준으로 단순 구성
+class GameInstance
+{
+public:
+	GameInstance();
+	~GameInstance();
+
+	// Init
+	// - 게임 실행에 필요한 초기 구성(씬 목록 구성, 초기 씬 설정)
+	void Init();
+
+	// Update
+	// - 매 프레임 게임을 갱신
+	// - 씬 전환 요청이 있는 경우 처리
+	void Update();
+
+	// Render
+	// - 매 프레임 렌더링 호출
+	void Render();
+
+	// RequestSceneChange
+	// - 씬 전환 요청 (즉시 전환하지 않고, 안전한 시점에 ApplySceneChange에서 처리)
+	// - bForceReload == true 인 경우, 동일 씬이어도 Destroy -> Init 수행
+	void RequestSceneChange(size_t index, bool bForceReload = false);
+
+private:
+	// ApplySceneChange
+	// - 씬 전환 요청을 처리
+	void ApplySceneChange();
+
+private:
+	// 씬 목록
+	std::vector<std::shared_ptr<Scene>> sceneList;
+
+	// 현재 활성 씬
+	std::shared_ptr<Scene> currentScene;
+
+	// NOTE: 
+	// - -1을 size_t로 캐스팅할 때 발생하는 가장 큰 값을 "없음"의 의미로 사용
+	// - 실제 값이 있다면 값에 해당하는 sceneIndex로 전환 요청
+	static constexpr size_t npos = static_cast<size_t>(-1);
+
+	// 현재 씬 인덱스
+	size_t currentSceneIndex = npos;
+
+	// 전환 대기 중 씬 인덱스
+	size_t pendingSceneIndex = npos;
+
+	// 동일 씬 다시 로드 여부
+	bool pendingForceReload = false;
+};

--- a/ProjectArenaDungeon/Managers/GraphicsManager.h
+++ b/ProjectArenaDungeon/Managers/GraphicsManager.h
@@ -1,10 +1,10 @@
 #pragma once
+
 // GraphicsManager
 // - DirectX11 Device, DeviceContext, SwapChain 및 렌더 타겟(RTV), 뷰포트를 관리
 // - 렌더링 시작(Begin) / 종료(End) 제공
 // - Sampler,Blend state 설정
 // - Window 생성(gHandle 값) 이후 초기화
-
 class GraphicsManager
 {
 	DECLARE_SINGLETON(GraphicsManager)

--- a/ProjectArenaDungeon/Managers/InputManager.h
+++ b/ProjectArenaDungeon/Managers/InputManager.h
@@ -6,7 +6,6 @@ constexpr size_t MAX_INPUT_KEY = 256;
 // InputManager
 // - 키보드 / 마우스 입력 상태를 프레임 단위로 갱신하여 Down, Up, Press 상태로 제공
 // - Update()는 매 프레임 1회 호출
-
 class InputManager
 {
 	DECLARE_SINGLETON(InputManager)

--- a/ProjectArenaDungeon/Managers/TimeManager.h
+++ b/ProjectArenaDungeon/Managers/TimeManager.h
@@ -1,9 +1,11 @@
 #pragma once
+
+#include <chrono>
+
 // TimeManager
 // - 프레임 기반 시간 정보(deltaTime, worldTime) 및 FPS를 계산/제공
 // - 목표 FPS(target FPS)가 설정된 경우 프레임 제한(WaitToTargetFrameRate()) 적용
 // - Update()는 매 프레임 1회 호출
-
 class TimeManager
 {
 	DECLARE_SINGLETON(TimeManager)

--- a/ProjectArenaDungeon/Objects/Object.cpp
+++ b/ProjectArenaDungeon/Objects/Object.cpp
@@ -4,7 +4,7 @@
 // Components
 #include "Components/Component.h"
 #include "Components/Transform.h"
-#include "Components/Collider.h"
+//#include "Components/Collider.h"
 
 Object::Object(const std::string& name, DirectX::SimpleMath::Vector2 position, DirectX::SimpleMath::Vector2 scale, float rotation)
 	: name(name)
@@ -60,29 +60,29 @@ void Object::Render()
 	}
 }
 
-void Object::OnCollisionEnter(Collider* other)
-{
-	if (!bActive)
-		return;
-
-	for (const auto& component : updateList)
-	{
-		if (component)
-			component->OnCollisionEnter(other);
-	}
-}
-
-void Object::OnCollisionExit(Collider* other)
-{
-	if (!bActive)
-		return;
-
-	for (const auto& component : updateList)
-	{
-		if (component)
-			component->OnCollisionExit(other);
-	}
-}
+//void Object::OnCollisionEnter(Collider* other)
+//{
+//	if (!bActive)
+//		return;
+//
+//	for (const auto& component : updateList)
+//	{
+//		if (component)
+//			component->OnCollisionEnter(other);
+//	}
+//}
+//
+//void Object::OnCollisionExit(Collider* other)
+//{
+//	if (!bActive)
+//		return;
+//
+//	for (const auto& component : updateList)
+//	{
+//		if (component)
+//			component->OnCollisionExit(other);
+//	}
+//}
 
 void Object::AddComponent(const std::shared_ptr<Component>& component)
 {

--- a/ProjectArenaDungeon/Objects/Object.cpp
+++ b/ProjectArenaDungeon/Objects/Object.cpp
@@ -1,0 +1,114 @@
+#include "pch.h"
+#include "Object.h"
+
+// Components
+#include "Components/Component.h"
+#include "Components/Transform.h"
+#include "Components/Collider.h"
+
+Object::Object(const std::string& name, DirectX::SimpleMath::Vector2 position, DirectX::SimpleMath::Vector2 scale, float rotation)
+	: name(name)
+{
+	transform = std::make_shared<Transform>();
+
+	transform->SetPosition(position);
+	transform->SetScale(scale);
+	transform->SetRotationDegree(rotation);
+
+	// NOTE: Transform은 항상 존재하며 updateList[0]에 배치된다.
+	AddComponent(transform);
+}
+
+void Object::Awake()
+{
+	if (!bActive)
+		return;
+
+	for (const auto& component : updateList)
+	{
+		if (component)
+			component->Awake();
+	}
+}
+
+void Object::Update()
+{
+	if (!bActive)
+		return;
+
+	// NOTE: Transform(0번)을 제외한 컴포넌트를 먼저 갱신한다.
+	for (size_t i = 1; i < updateList.size(); ++i)
+	{
+		if (updateList[i])
+			updateList[i]->Update();
+	}
+
+	// NOTE: Transform은 마지막에 1회만 업데이트한다.
+	if (transform)
+		transform->Update();
+}
+
+void Object::Render()
+{
+	if (!bActive)
+		return;
+
+	for (const auto& component : updateList)
+	{
+		if (component)
+			component->Render();
+	}
+}
+
+void Object::OnCollisionEnter(Collider* other)
+{
+	if (!bActive)
+		return;
+
+	for (const auto& component : updateList)
+	{
+		if (component)
+			component->OnCollisionEnter(other);
+	}
+}
+
+void Object::OnCollisionExit(Collider* other)
+{
+	if (!bActive)
+		return;
+
+	for (const auto& component : updateList)
+	{
+		if (component)
+			component->OnCollisionExit(other);
+	}
+}
+
+void Object::AddComponent(const std::shared_ptr<Component>& component)
+{
+	if (!component)
+		return;
+
+	const std::string& compName = component->GetName();
+
+	auto [it, inserted] = components.try_emplace(compName, component);
+	if (!inserted)
+		return;
+
+	component->SetOwner(this);
+
+	// NOTE: Transform은 항상 updateList[0]에 유지한다.
+	if (auto asTransform = std::dynamic_pointer_cast<Transform>(component))
+	{
+		transform = asTransform;
+
+		if (updateList.empty())
+			updateList.emplace_back(component);
+		else
+			updateList[0] = component;
+
+		return;
+	}
+
+	updateList.emplace_back(component);
+}

--- a/ProjectArenaDungeon/Objects/Object.h
+++ b/ProjectArenaDungeon/Objects/Object.h
@@ -36,13 +36,13 @@ public:
 	// - 매 프레임 렌더링 호출
 	virtual void Render();
 
-	// OnCollisionEnter
-	// - 충돌 시작 시점 이벤트 전달
-	virtual void OnCollisionEnter(Collider* other);
-
-	// OnCollisionExit
-	// - 충돌 종료 시점 이벤트 전달
-	virtual void OnCollisionExit(Collider* other);
+	//// OnCollisionEnter
+	//// - 충돌 시작 시점 이벤트 전달
+	//virtual void OnCollisionEnter(Collider* other);
+	//
+	//// OnCollisionExit
+	//// - 충돌 종료 시점 이벤트 전달
+	//virtual void OnCollisionExit(Collider* other);
 
 	// AddComponent
 	// - 컴포넌트를 오브젝트에 결합

--- a/ProjectArenaDungeon/Objects/Object.h
+++ b/ProjectArenaDungeon/Objects/Object.h
@@ -1,0 +1,90 @@
+#pragma once
+
+#include <unordered_map>
+
+class Component;
+class Transform;
+class Collider;
+
+// Object
+// - 씬에 존재하는 모든 실체의 기반 클래스
+// - Transform을 기본으로 보유하며, 컴포넌트를 결합하여 기능을 확장
+class Object
+{
+public:
+	Object(const std::string& name, 
+		DirectX::SimpleMath::Vector2 position = VEC2_ZERO,
+		DirectX::SimpleMath::Vector2 scale = VEC2_ONE,
+		float rotation = 0.0f);
+
+	virtual ~Object() = default;
+
+	// Awake
+	// - 컴포넌트 초기화 진입점
+	// - 씬에 배치된 직후(또는 활성화 직후) 1회 호출
+	virtual void Awake();
+
+	// Update
+	// - 매 프레임 호출되는 갱신 함수
+	// - Transform은 다른 컴포넌트들의 변경이 끝난 뒤 마지막에 1회만 업데이트
+	virtual void Update();
+
+	// Render
+	// - 매 프레임 렌더링 호출
+	virtual void Render();
+
+	// OnCollisionEnter
+	// - 충돌 시작 시점 이벤트 전달
+	virtual void OnCollisionEnter(Collider* other);
+
+	// OnCollisionExit
+	// - 충돌 종료 시점 이벤트 전달
+	virtual void OnCollisionExit(Collider* other);
+
+	// AddComponent
+	// - 컴포넌트를 오브젝트에 결합
+	// - 동일 이름 컴포넌트가 이미 존재하면 추가하지 않음
+	void AddComponent(const std::shared_ptr<Component>& component);
+
+	template<typename T>
+	std::shared_ptr<T> GetComponent(const std::string& compName) const
+	{
+		auto it = components.find(compName);
+		if (it == components.end())
+			return nullptr;
+
+		return std::dynamic_pointer_cast<T>(it->second);
+	}
+
+	// GetTransform
+	// - 오브젝트의 Transform 접근자
+	Transform* GetTransform() { return transform.get(); }
+	const Transform* GetTransform() const { return transform.get(); }
+
+	// GetObjectName
+	// - 디버깅/식별을 위한 이름 반환
+	const std::string& GetObjectName() const { return name; }
+
+	// SetActive
+	// - 오브젝트 활성/비활성 상태 변경
+	void SetActive(bool value) { bActive = value; }
+
+	// IsActive
+	// - 오브젝트가 활성 상태인지 반환
+	bool IsActive() const { return bActive; }
+
+protected:
+	std::string name;
+
+	// NOTE: Object는 Transform을 반드시 보유한다.
+	std::shared_ptr<Transform> transform;
+
+	// NOTE: key는 컴포넌트 고유 이름이며 중복되면 결합하지 않는다.
+	std::unordered_map<std::string, std::shared_ptr<Component>> components;
+
+	// NOTE: Transform은 updateList[0]에 고정 배치하고,
+	//       Update()에서는 Transform을 제외한 컴포넌트를 먼저 갱신한 뒤 Transform을 마지막에 업데이트한다.
+	std::vector<std::shared_ptr<Component>> updateList;
+
+	bool bActive = true;
+};

--- a/ProjectArenaDungeon/Objects/Object.h
+++ b/ProjectArenaDungeon/Objects/Object.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#include <string>
+#include <memory>
 #include <unordered_map>
+#include <vector>
 
 class Component;
 class Transform;

--- a/ProjectArenaDungeon/ProjectArenaDungeon.vcxproj
+++ b/ProjectArenaDungeon/ProjectArenaDungeon.vcxproj
@@ -149,6 +149,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="Components\Components.cpp" />
     <ClCompile Include="GameInstance.cpp" />
     <ClCompile Include="Main.cpp" />
     <ClCompile Include="Managers\GraphicsManager.cpp" />
@@ -174,6 +175,7 @@
     <ClCompile Include="Window.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="Components\Component.h" />
     <ClInclude Include="GameInstance.h" />
     <ClInclude Include="Managers\GraphicsManager.h" />
     <ClInclude Include="Managers\InputManager.h" />

--- a/ProjectArenaDungeon/ProjectArenaDungeon.vcxproj
+++ b/ProjectArenaDungeon/ProjectArenaDungeon.vcxproj
@@ -149,6 +149,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="GameInstance.cpp" />
     <ClCompile Include="Main.cpp" />
     <ClCompile Include="Managers\GraphicsManager.cpp" />
     <ClCompile Include="Managers\InputManager.cpp" />
@@ -171,6 +172,7 @@
     <ClCompile Include="Window.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="GameInstance.h" />
     <ClInclude Include="Managers\GraphicsManager.h" />
     <ClInclude Include="Managers\InputManager.h" />
     <ClInclude Include="Managers\ShaderManager.h" />

--- a/ProjectArenaDungeon/ProjectArenaDungeon.vcxproj
+++ b/ProjectArenaDungeon/ProjectArenaDungeon.vcxproj
@@ -150,6 +150,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="Components\Components.cpp" />
+    <ClCompile Include="Components\Transform.cpp" />
     <ClCompile Include="GameInstance.cpp" />
     <ClCompile Include="Main.cpp" />
     <ClCompile Include="Managers\GraphicsManager.cpp" />
@@ -176,6 +177,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Components\Component.h" />
+    <ClInclude Include="Components\Transform.h" />
     <ClInclude Include="GameInstance.h" />
     <ClInclude Include="Managers\GraphicsManager.h" />
     <ClInclude Include="Managers\InputManager.h" />

--- a/ProjectArenaDungeon/ProjectArenaDungeon.vcxproj
+++ b/ProjectArenaDungeon/ProjectArenaDungeon.vcxproj
@@ -156,6 +156,7 @@
     <ClCompile Include="Managers\ShaderManager.cpp" />
     <ClCompile Include="Managers\TextureManager.cpp" />
     <ClCompile Include="Managers\TimeManager.cpp" />
+    <ClCompile Include="Objects\Object.cpp" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
     </ClCompile>
@@ -179,6 +180,7 @@
     <ClInclude Include="Managers\ShaderManager.h" />
     <ClInclude Include="Managers\TextureManager.h" />
     <ClInclude Include="Managers\TimeManager.h" />
+    <ClInclude Include="Objects\Object.h" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="Renders\ConstantBuffers\ConstantBuffer.h" />
     <ClInclude Include="Renders\ConstantBuffers\GlobalBuffers.h" />

--- a/ProjectArenaDungeon/ProjectArenaDungeon.vcxproj
+++ b/ProjectArenaDungeon/ProjectArenaDungeon.vcxproj
@@ -169,6 +169,7 @@
     <ClCompile Include="Resources\Mesh.cpp" />
     <ClCompile Include="Resources\Texture.cpp" />
     <ClCompile Include="Resources\VertexType.cpp" />
+    <ClCompile Include="Scenes\TestScenes\Scene_TestFeature.cpp" />
     <ClCompile Include="Window.cpp" />
   </ItemGroup>
   <ItemGroup>
@@ -191,6 +192,9 @@
     <ClInclude Include="Resources\Mesh.h" />
     <ClInclude Include="Resources\Texture.h" />
     <ClInclude Include="Resources\VertexType.h" />
+    <ClInclude Include="Scenes\Scene.h" />
+    <ClInclude Include="Scenes\SceneList.h" />
+    <ClInclude Include="Scenes\TestScenes\Scene_TestFeature.h" />
     <ClInclude Include="targetver.h" />
     <ClInclude Include="Window.h" />
   </ItemGroup>

--- a/ProjectArenaDungeon/ProjectArenaDungeon.vcxproj.filters
+++ b/ProjectArenaDungeon/ProjectArenaDungeon.vcxproj.filters
@@ -13,6 +13,24 @@
     <Filter Include="Renders\IA">
       <UniqueIdentifier>{1998f8eb-5b5d-4b17-9799-083eb774fc77}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Components">
+      <UniqueIdentifier>{9c4d37de-d1cb-480c-9cd9-6d90f73af201}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Objects">
+      <UniqueIdentifier>{ecd635fe-7933-47b4-b3a0-7788adc2b72d}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Renders\Shaders">
+      <UniqueIdentifier>{43333cc6-d292-4ea0-ad78-8a797592804b}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Resources">
+      <UniqueIdentifier>{cfa6228e-8beb-4de7-8af5-6fa241b14bc7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Scenes">
+      <UniqueIdentifier>{54ac301c-78c5-4b5c-92bb-f86e2b551f21}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Scenes\TestScenes">
+      <UniqueIdentifier>{2c8525f5-278f-48b3-a9b4-db24a364520c}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Main.cpp" />
@@ -35,6 +53,46 @@
     </ClCompile>
     <ClCompile Include="Renders\IA\VertexBuffer.cpp">
       <Filter>Renders\IA</Filter>
+    </ClCompile>
+    <ClCompile Include="GameInstance.cpp" />
+    <ClCompile Include="Components\Components.cpp">
+      <Filter>Components</Filter>
+    </ClCompile>
+    <ClCompile Include="Components\Transform.cpp">
+      <Filter>Components</Filter>
+    </ClCompile>
+    <ClCompile Include="Managers\ShaderManager.cpp">
+      <Filter>Managers</Filter>
+    </ClCompile>
+    <ClCompile Include="Managers\TextureManager.cpp">
+      <Filter>Managers</Filter>
+    </ClCompile>
+    <ClCompile Include="Objects\Object.cpp">
+      <Filter>Objects</Filter>
+    </ClCompile>
+    <ClCompile Include="Renders\Shaders\Shader.cpp">
+      <Filter>Renders\Shaders</Filter>
+    </ClCompile>
+    <ClCompile Include="Renders\Shaders\VertexShader.cpp">
+      <Filter>Renders\Shaders</Filter>
+    </ClCompile>
+    <ClCompile Include="Renders\Shaders\PixelShader.cpp">
+      <Filter>Renders\Shaders</Filter>
+    </ClCompile>
+    <ClCompile Include="Resources\Material.cpp">
+      <Filter>Resources</Filter>
+    </ClCompile>
+    <ClCompile Include="Resources\Mesh.cpp">
+      <Filter>Resources</Filter>
+    </ClCompile>
+    <ClCompile Include="Resources\Texture.cpp">
+      <Filter>Resources</Filter>
+    </ClCompile>
+    <ClCompile Include="Resources\VertexType.cpp">
+      <Filter>Resources</Filter>
+    </ClCompile>
+    <ClCompile Include="Scenes\TestScenes\Scene_TestFeature.cpp">
+      <Filter>Scenes\TestScenes</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -64,6 +122,52 @@
     </ClInclude>
     <ClInclude Include="Renders\IA\VertexBuffer.h">
       <Filter>Renders\IA</Filter>
+    </ClInclude>
+    <ClInclude Include="GameInstance.h" />
+    <ClInclude Include="Components\Component.h">
+      <Filter>Components</Filter>
+    </ClInclude>
+    <ClInclude Include="Components\Transform.h">
+      <Filter>Components</Filter>
+    </ClInclude>
+    <ClInclude Include="Managers\ShaderManager.h">
+      <Filter>Managers</Filter>
+    </ClInclude>
+    <ClInclude Include="Managers\TextureManager.h">
+      <Filter>Managers</Filter>
+    </ClInclude>
+    <ClInclude Include="Objects\Object.h">
+      <Filter>Objects</Filter>
+    </ClInclude>
+    <ClInclude Include="Renders\Shaders\Shader.h">
+      <Filter>Renders\Shaders</Filter>
+    </ClInclude>
+    <ClInclude Include="Renders\Shaders\VertexShader.h">
+      <Filter>Renders\Shaders</Filter>
+    </ClInclude>
+    <ClInclude Include="Renders\Shaders\PixelShader.h">
+      <Filter>Renders\Shaders</Filter>
+    </ClInclude>
+    <ClInclude Include="Resources\Material.h">
+      <Filter>Resources</Filter>
+    </ClInclude>
+    <ClInclude Include="Resources\Mesh.h">
+      <Filter>Resources</Filter>
+    </ClInclude>
+    <ClInclude Include="Resources\Texture.h">
+      <Filter>Resources</Filter>
+    </ClInclude>
+    <ClInclude Include="Resources\VertexType.h">
+      <Filter>Resources</Filter>
+    </ClInclude>
+    <ClInclude Include="Scenes\TestScenes\Scene_TestFeature.h">
+      <Filter>Scenes\TestScenes</Filter>
+    </ClInclude>
+    <ClInclude Include="Scenes\Scene.h">
+      <Filter>Scenes</Filter>
+    </ClInclude>
+    <ClInclude Include="Scenes\SceneList.h">
+      <Filter>Scenes</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/ProjectArenaDungeon/Renders/IA/IndexBuffer.h
+++ b/ProjectArenaDungeon/Renders/IA/IndexBuffer.h
@@ -1,8 +1,10 @@
 #pragma once
+
+#include <vector>
+
 // IndexBuffer
 // - 렌더링 파이프라인의 IA(Input Assembler) 단계에서 사용하는 인덱스 버퍼 클래스
 // - 인덱스 데이터 생성(Create) 및 IA 바인딩(Bind)
-
 class IndexBuffer
 {
 public:

--- a/ProjectArenaDungeon/Renders/IA/InputLayout.h
+++ b/ProjectArenaDungeon/Renders/IA/InputLayout.h
@@ -1,9 +1,11 @@
 #pragma once
+
+#include <span>
+
 // InputLayout
 // - 렌더링 파이프라인 IA(Input Assembler) 단계에서 사용하는 입력 레이아웃 래퍼
 // - VertexShader의 입력(Blob)과 정점 레이아웃(D3D11_INPUT_ELEMENT_DESC)을 기반으로 생성(Create)
 // - IA 단계 바인딩(Bind)
-
 class InputLayout
 {
 public:

--- a/ProjectArenaDungeon/Renders/IA/VertexBuffer.h
+++ b/ProjectArenaDungeon/Renders/IA/VertexBuffer.h
@@ -1,8 +1,10 @@
 #pragma once
+
+#include <vector>
+
 // VertexBuffer
 // - 렌더링 파이프라인의 IA(Input Assembler) 단계에서 사용하는 정점 버퍼 클래스
 // - 정점 데이터 생성(Create) 및 IA 바인딩(Bind)
-
 class VertexBuffer
 {
 public:

--- a/ProjectArenaDungeon/Renders/Shaders/PixelShader.h
+++ b/ProjectArenaDungeon/Renders/Shaders/PixelShader.h
@@ -2,6 +2,8 @@
 #include "pch.h"
 #include "Shader.h"
 
+#include <string>
+
 // PixelShader
 // - HLSL Pixel Shader를 컴파일하고 PixelShader 리소스를 생성하는 클래스
 class PixelShader : public Shader

--- a/ProjectArenaDungeon/Renders/Shaders/Shader.h
+++ b/ProjectArenaDungeon/Renders/Shaders/Shader.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 // Shader
 // - 셰이더 기반 클래스
 // - 파생 클래스(VertexShader / PixelShader)에서 실제 리소스 생성(Create) 및 바인딩(Bind)을 구현

--- a/ProjectArenaDungeon/Renders/Shaders/VertexShader.h
+++ b/ProjectArenaDungeon/Renders/Shaders/VertexShader.h
@@ -2,6 +2,8 @@
 #include "pch.h"
 #include "Shader.h"
 
+#include <string>
+
 // VertexShader
 // - HLSL Vertex Shader를 컴파일하고 Vertex Shader 리소스를 생성하는 클래스
 // - InputLayout 생성 시 필요한 바이트코드(blob)를 보관

--- a/ProjectArenaDungeon/Resources/Material.h
+++ b/ProjectArenaDungeon/Resources/Material.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <string>
+#include <span>
+
 class ColorBuffer;
 class FrameBuffer;
 class InputLayout;

--- a/ProjectArenaDungeon/Resources/Texture.h
+++ b/ProjectArenaDungeon/Resources/Texture.h
@@ -3,7 +3,6 @@
 // Texture
 // - 이미지 파일을 로드하고 ShaderResourceView(SRV)를 생성/관리하는 클래스
 // - DirectXTex(LoadFromDDS/TGA/WIC, GenerateMipMaps)를 사용하여 다양한 포맷에 대응
-
 class Texture
 {
 public:
@@ -17,7 +16,7 @@ public:
 	void Bind(UINT slot = 0);
 
 	std::wstring GetPath() const { return path; }
-	DirectX::SimpleMath::Vector2 GetSize() const { return DirectX::SimpleMath::Vector2((float)metaData.width, (float)metaData.height); }
+	DirectX::SimpleMath::Vector2 GetSize() const { return DirectX::SimpleMath::Vector2(static_cast<float>(metaData.width), static_cast<float>(metaData.height)); }
 	Microsoft::WRL::ComPtr<ID3D11ShaderResourceView> GetSRV() const { return srv; }
 
 private:

--- a/ProjectArenaDungeon/Resources/VertexType.h
+++ b/ProjectArenaDungeon/Resources/VertexType.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <vector>
+
 // VertexType
 // - InputLayout 생성에 필요한 입력 description과 정점 데이터 구조를 정의
 

--- a/ProjectArenaDungeon/Scenes/Scene.h
+++ b/ProjectArenaDungeon/Scenes/Scene.h
@@ -1,0 +1,62 @@
+#pragma once
+#include <memory>
+#include <vector>
+#include <utility>
+
+class Object;
+class GameContext;     // 런 전체 상태
+class DirectorSystem;  // 전투/이벤트/선택 흐름 제어
+
+class Scene
+{
+public:
+	virtual ~Scene() = default;
+
+	// Init
+	// - 씬 진입 시 1회 호출
+	// - 필요한 Object 생성, 초기 상태 세팅
+	virtual void Init() = 0;
+
+	// Destroy
+	// - 씬 종료 시 1회 호출
+	// - 오브젝트 해제, 임시 리소스 정리
+	virtual void Destroy() = 0;
+
+	// Update
+	// - 매 프레임 로직 처리
+	virtual void Update()
+	{
+		for (const auto& object : objects)
+			object->Update();
+	}
+
+	// Render
+	// - 매 프레임 렌더링
+	virtual void Render()
+	{
+		for (const auto& object : objects)
+			object->Render();
+	}
+
+	// AddObject
+	// - 씬에 Object 추가
+	void AddObject(std::shared_ptr<Object> object)
+	{
+		object->Awake();
+		objects.push_back(std::move(object));
+	}
+
+	// Context / Director 연결
+	void SetContext(GameContext* context) { gameContext = context; }
+	void SetDirector(DirectorSystem* director) { directorSystem = director; }
+
+protected:
+	// 씬에 소속된 오브젝트 목록
+	std::vector<std::shared_ptr<Object>> objects;
+
+	// 런 전체 상태 (씬 외부 데이터)
+	GameContext* gameContext = nullptr;
+
+	// 게임 흐름 제어자 (선택, 전투 흐름, 결과 반영)
+	DirectorSystem* directorSystem = nullptr;
+};

--- a/ProjectArenaDungeon/Scenes/Scene.h
+++ b/ProjectArenaDungeon/Scenes/Scene.h
@@ -3,7 +3,8 @@
 #include <vector>
 #include <utility>
 
-class Object;
+#include "Objects/Object.h"
+
 class GameContext;     // 런 전체 상태
 class DirectorSystem;  // 전투/이벤트/선택 흐름 제어
 

--- a/ProjectArenaDungeon/Scenes/SceneList.h
+++ b/ProjectArenaDungeon/Scenes/SceneList.h
@@ -1,0 +1,12 @@
+#pragma once
+//// Game scenes (예정)
+//#include "Scenes/Scene_Title.h"
+//#include "Scenes/Scene_Loadout.h"
+//#include "Scenes/Scene_NormalBattle.h"
+//#include "Scenes/Scene_BossBattle.h"
+//#include "Scenes/Scene_Reward.h"
+//#include "Scenes/Scene_GameOver.h"
+//
+//// Test scenes (디버그 / 개발 전용)
+//#include "Scenes/TestScenes/Scene_TestBattle.h"
+#include "Scenes/TestScenes/Scene_TestFeature.h"

--- a/ProjectArenaDungeon/Scenes/TestScenes/Scene_TestFeature.cpp
+++ b/ProjectArenaDungeon/Scenes/TestScenes/Scene_TestFeature.cpp
@@ -1,0 +1,22 @@
+#include "pch.h"
+#include "Scene_TestFeature.h"
+
+void Scene_TestFeature::Init()
+{
+
+}
+
+void Scene_TestFeature::Destroy()
+{
+
+}
+
+void Scene_TestFeature::Update()
+{
+
+}
+
+void Scene_TestFeature::Render()
+{
+
+}

--- a/ProjectArenaDungeon/Scenes/TestScenes/Scene_TestFeature.h
+++ b/ProjectArenaDungeon/Scenes/TestScenes/Scene_TestFeature.h
@@ -1,0 +1,15 @@
+#pragma once
+#include "Scenes/Scene.h"
+
+class Scene_TestFeature : public Scene
+{
+public:
+	void Init() override;
+	void Destroy() override;
+
+	void Update() override;
+	void Render() override;
+
+private:
+
+};

--- a/ProjectArenaDungeon/Window.cpp
+++ b/ProjectArenaDungeon/Window.cpp
@@ -1,5 +1,8 @@
 #include "pch.h"
 #include "Window.h"
+#include "GameInstance.h"
+
+std::unique_ptr<GameInstance> Window::gameInstance = nullptr;
 
 Window::Window(const WinDesc& initDesc)
     :desc(initDesc)
@@ -85,6 +88,9 @@ ATOM Window::MyRegisterClass(const WinDesc& initDesc)
 
 WPARAM Window::Run()
 {
+    gameInstance = std::make_unique<GameInstance>();
+    gameInstance->Init();
+
     MSG msg;
 
     // Å¸°Ù FPS ¼³Á¤(144)
@@ -108,9 +114,11 @@ WPARAM Window::Run()
             INPUT.Update();
             TIME.Update();
 
+            gameInstance->Update();
+
             GRAPHICS.Begin();
             {
-
+                gameInstance->Render();
             }
             GRAPHICS.End();
 

--- a/ProjectArenaDungeon/Window.h
+++ b/ProjectArenaDungeon/Window.h
@@ -1,5 +1,7 @@
 #pragma once
 
+class GameInstance;
+
 // WinDesc
 // - 윈도우 생성에 피룡한 초기 설정 정보
 // - 앱 이름, 인스턴스 핸들, 윈도우 핸들, 초기 크기 정보
@@ -40,4 +42,6 @@ private:
 	static LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
 
 	WinDesc desc;
+
+	static std::unique_ptr<GameInstance> gameInstance;
 };

--- a/ProjectArenaDungeon/Window.h
+++ b/ProjectArenaDungeon/Window.h
@@ -3,7 +3,7 @@
 class GameInstance;
 
 // WinDesc
-// - 윈도우 생성에 피룡한 초기 설정 정보
+// - 윈도우 생성에 필요한 초기 설정 정보
 // - 앱 이름, 인스턴스 핸들, 윈도우 핸들, 초기 크기 정보
 struct WinDesc
 {
@@ -17,6 +17,7 @@ struct WinDesc
 // Window
 // - 윈도우 생성 및 메시지 루프를 관리하는 클래스
 // - 윈도우 클래스 등록, 윈도우 생성, 메시지 루프(Run)
+// - GameInstance를 생성하고 메인 루프에서 Update / Render 호출
 class Window
 {
 public:

--- a/ProjectArenaDungeon/pch.h
+++ b/ProjectArenaDungeon/pch.h
@@ -22,6 +22,7 @@
 #include <cassert>
 
 // C++ runtime header
+#include <cstddef>
 #include <string>
 #include <memory>
 #include <iostream>

--- a/ProjectArenaDungeon/pch.h
+++ b/ProjectArenaDungeon/pch.h
@@ -32,6 +32,7 @@
 #include <span>
 #include <unordered_map>
 #include <algorithm>
+#include <utility>
 
 // DirectX D3D11
 #include <d3d11.h>

--- a/ProjectArenaDungeon/pch.h
+++ b/ProjectArenaDungeon/pch.h
@@ -58,6 +58,8 @@ extern float gWinHeight;
 
 // Constants
 constexpr float epsilon = 1e-5f;
+constexpr DirectX::SimpleMath::Vector2 VEC2_ZERO = DirectX::SimpleMath::Vector2(0.0f, 0.0f);
+constexpr DirectX::SimpleMath::Vector2 VEC2_ONE = DirectX::SimpleMath::Vector2(1.0f, 1.0f);
 
 // Window default size
 #define WIN_DEFAULT_WIDTH 1280


### PR DESCRIPTION
## Overview
GameInstance / Scene 기반 구조를 도입하고, Object-Component 구조 및 Transform 컴포넌트를 추가하여 기본적인 씬 전환과 오브젝트 구성의 뼈대를 구축합니다.

---

## Changes
- GameInstance 작성
  - Scene 기반 클래스와 테스트용 Scene 생성을 전제한 구조 도입
  - Request → Apply 방식의 씬 전환 구조 구현
  - forceReload 플래그 기반 강제 씬 로드 기능 추가
  - currentSceneIndex를 통한 현재 씬 인덱스 관리
  - Window 기본 메시지 루프에 GameInstance Update/Render 연결

- Scene 기반 클래스 추가
  - Init/Destroy를 강제하는 Scene 기반 클래스 작성
  - 기본 Update/Render 루프 구성
  - SceneList 구성 및 테스트 씬(Scene_TestFeature) 등록
  - GameContext / DirectorSystem 연동 포인트 추가

- Object / Component 기반 구조 도입
  - 씬에 배치되는 모든 오브젝트의 기반 클래스(Object) 작성
  - Transform을 기본 컴포넌트로 보유하는 구조 도입
  - 컴포넌트 결합/조회(AddComponent, GetComponent) 구조 추가
  - Transform은 마지막에 갱신되는 업데이트 정책 명시
  - 오브젝트 활성/비활성 플래그 도입 (Object Pool 확장 대응)

- Component 기반 클래스 추가
  - Object에 결합되는 컴포넌트 기반 클래스 작성
  - 컴포넌트 식별 이름 및 소유 오브젝트(owner) 연결 구조 추가
  - Awake / Update / Render 가상 함수 정의
  - 충돌 이벤트 콜백(OnCollisionEnter / OnCollisionExit) 인터페이스 추가

- Transform 컴포넌트 추가
  - 위치/회전/스케일 기반 SRT 월드 행렬 계산
  - right, up 로컬 축 벡터 캐싱
  - dirty 플래그 기반 변경 시점에만 월드 행렬 갱신

- 코드 정리
  - .h 파일에서 필요한 STL/타입 직접 include
  - Collider 컴포넌트 생성 전제 코드 주석 처리
  - 프로젝트 필터 구조 실제 파일 경로와 동일하게 정리

---

## Purpose
- GameInstance/Scene 구조를 통해 게임 루프와 씬 전환의 기본 골격을 마련
- Object-Component 구조를 도입하여 게임 오브젝트 확장 기반 확보
- Transform 컴포넌트를 통해 공간 정보 관리 및 렌더링 연계의 기준점 생성
- 이후 캐릭터, 투사체, 충돌 컴포넌트 확장을 위한 구조적 토대 구축

---

## How to Test
1. 디버그 모드로 빌드
2. 추가한 코드에 대해 컴파일 에러 및 경고 여부 확인
3. 디버그 전용 콘솔창 출력을 이용해 테스트 씬(Scene_TestFeature) 정상 로드 여부 확인
4. 테스트용 오브젝트 생성 확인

---

## Notes
- 충돌 이벤트 콜백은 구조만 마련되어 있으며 실제 물리 연동은 이후 PR에서 진행 예정
- Scene 전환 정책(forceReload, index 관리)은 추후 세분화 가능성 있음

Closes to #18 