### PR TITLE
feat: PhysicsManager 도입 및 RigidBody 컴포넌트 추가

### DIFF
--- a/ProjectArenaDungeon/Components/RigidBody.cpp
+++ b/ProjectArenaDungeon/Components/RigidBody.cpp
@@ -1,0 +1,141 @@
+#include "pch.h"
+#include "Components/RigidBody.h"
+
+#include "Objects/Object.h"
+#include "Components/Transform.h"
+
+#include "Managers/PhysicsManager.h"
+#include "Utilities/PhysicsUtility.h"
+
+using Vector2 = DirectX::SimpleMath::Vector2;
+
+RigidBody::RigidBody(BodyType type, std::string name)
+	: Component(std::move(name)), type(type)
+{
+	bodyDef = b2DefaultBodyDef();
+	bodyDef.type = static_cast<b2BodyType>(type);
+
+	// NOTE: 생성 이후 옵션 변경이 있을 수 있으므로 bodyDef에도 값을 유지한다.
+}
+
+RigidBody::~RigidBody()
+{
+	if (b2Body_IsValid(bodyId))
+	{
+		b2DestroyBody(bodyId);
+		bodyId = b2_nullBodyId;
+	}
+}
+
+void RigidBody::Awake()
+{
+	if (!owner)
+		return;
+
+	const b2WorldId worldId = PHYSICS.GetWorldId();
+	if (!b2World_IsValid(worldId))
+		return;
+
+	auto* tr = owner->GetTransform();
+	if (!tr)
+		return;
+
+	bodyDef.position = PhysicsUtility::ScreenToWorld(tr->GetPosition());
+	bodyDef.rotation = b2MakeRot(-tr->GetRotationRadian());
+	bodyDef.userData = owner;
+
+	bodyId = b2CreateBody(worldId, &bodyDef);
+
+	// NOTE: bodyDef에 저장된 옵션을 실제 바디에도 반영한다.
+	if (b2Body_IsValid(bodyId))
+	{
+		b2Body_SetLinearDamping(bodyId, bodyDef.linearDamping);
+		b2Body_SetAngularDamping(bodyId, bodyDef.angularDamping);
+		b2Body_SetFixedRotation(bodyId, bodyDef.fixedRotation);
+	}
+}
+
+void RigidBody::Update()
+{
+	if (!owner)
+		return;
+
+	if (!b2Body_IsValid(bodyId))
+		return;
+
+	// NOTE: Static 바디는 물리 결과로 Transform이 변하지 않으므로 동기화하지 않는다.
+	if (bodyDef.type == b2_staticBody)
+		return;
+
+	const b2Vec2 pos = b2Body_GetPosition(bodyId);
+	const float angle = b2Rot_GetAngle(b2Body_GetRotation(bodyId));
+
+	auto* tr = owner->GetTransform();
+	if (!tr)
+		return;
+
+	tr->SetPosition(PhysicsUtility::WorldToScreen(pos));
+	tr->SetRotationRadian(-angle);
+}
+
+void RigidBody::SetPosition(const Vector2& position)
+{
+	if (!b2Body_IsValid(bodyId))
+		return;
+
+	const b2Vec2 pos = PhysicsUtility::ScreenToWorld(position);
+	const b2Rot rot = b2Body_GetRotation(bodyId);
+
+	b2Body_SetTransform(bodyId, pos, rot);
+	b2Body_SetAwake(bodyId, true);
+}
+
+void RigidBody::SetRotationRadian(float radian)
+{
+	bodyDef.rotation = b2MakeRot(-radian);
+
+	if (!b2Body_IsValid(bodyId))
+		return;
+
+	const b2Vec2 pos = b2Body_GetPosition(bodyId);
+
+	b2Body_SetTransform(bodyId, pos, b2MakeRot(-radian));
+
+	// NOTE: 강제 회전 변경 시 현재 각속도는 끊어주는 편이 안전하다.
+	b2Body_SetAngularVelocity(bodyId, 0.0f);
+
+	if (owner && owner->GetTransform())
+		owner->GetTransform()->SetRotationRadian(radian);
+
+	b2Body_SetAwake(bodyId, true);
+}
+
+void RigidBody::SetVelocity(const Vector2& velocity)
+{
+	if (!b2Body_IsValid(bodyId))
+		return;
+
+	b2Body_SetLinearVelocity(bodyId, PhysicsUtility::ScreenToWorld(velocity));
+}
+
+void RigidBody::SetDamping(float linear, float angular)
+{
+	bodyDef.linearDamping = linear;
+	bodyDef.angularDamping = angular;
+
+	if (!b2Body_IsValid(bodyId))
+		return;
+
+	b2Body_SetLinearDamping(bodyId, linear);
+	b2Body_SetAngularDamping(bodyId, angular);
+}
+
+void RigidBody::SetFixedRotation(bool fixed)
+{
+	bodyDef.fixedRotation = fixed;
+
+	if (!b2Body_IsValid(bodyId))
+		return;
+
+	b2Body_SetFixedRotation(bodyId, fixed);
+}

--- a/ProjectArenaDungeon/Components/RigidBody.h
+++ b/ProjectArenaDungeon/Components/RigidBody.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <string>
+
+// Box2D
+#include <box2d/box2d.h>
+
+// DirectXTK SimpleMath
+#include "_Libraries/DirectXTK/SimpleMath.h"
+
+#include "Components/Component.h"
+
+enum class BodyType
+{
+	Static = b2_staticBody,
+	Dynamic = b2_dynamicBody,
+	Kinematic = b2_kinematicBody,
+};
+
+// RigidBody
+// - Box2D 바디를 생성하고 Transform과 물리 상태를 동기화
+// - 픽셀 좌표계를 물리 좌표계(미터)로 변환하여 월드에 반영
+class RigidBody : public Component
+{
+public:
+	explicit RigidBody(BodyType type = BodyType::Dynamic, std::string name = "RigidBody");
+	~RigidBody() override;
+
+	// Awake
+	// - 현재 Transform 기준으로 Box2D 바디를 생성
+	// - 월드가 유효하지 않으면 생성하지 않음
+	void Awake() override;
+
+	// Update
+	// - Box2D 바디의 위치/회전을 Transform에 반영
+	// - Static 바디는 스킵
+	void Update() override;
+
+	// SetPosition
+	// - 바디 위치를 픽셀 좌표로 지정하고 월드 변환으로 적용
+	void SetPosition(const DirectX::SimpleMath::Vector2& position);
+
+	// SetRotationRadian
+	// - 바디 회전을 라디안으로 지정
+	// - 엔진 회전 방향 정책에 맞춰 Box2D 각도 부호를 변환
+	void SetRotationRadian(float radian);
+
+	// SetVelocity
+	// - 선속도를 픽셀/초 기준으로 지정하고 월드 변환으로 적용
+	void SetVelocity(const DirectX::SimpleMath::Vector2& velocity);
+
+	// SetDamping
+	// - 선/각 감쇠를 설정하고, 생성된 바디에 반영
+	void SetDamping(float linear, float angular);
+
+	// SetFixedRotation
+	// - 회전 고정 여부를 설정하고, 생성된 바디에 반영
+	void SetFixedRotation(bool fixed);
+
+	b2BodyId GetBodyId() const { return bodyId; }
+	BodyType GetBodyType() const { return type; }
+
+private:
+	BodyType type = BodyType::Dynamic;
+
+	b2BodyId bodyId = b2_nullBodyId;
+	b2BodyDef bodyDef{};
+};

--- a/ProjectArenaDungeon/Components/Transform.cpp
+++ b/ProjectArenaDungeon/Components/Transform.cpp
@@ -1,5 +1,6 @@
 #include "pch.h"
 #include "Components/Transform.h"
+#include "Config/ConstantValues.h"
 
 #include "Renders/ConstantBuffers/GlobalBuffers.h"
 

--- a/ProjectArenaDungeon/Config/ConstantValues.h
+++ b/ProjectArenaDungeon/Config/ConstantValues.h
@@ -1,0 +1,10 @@
+#pragma once
+// DirectXTK SimpleMath
+#include "_Libraries/DirectXTK/SimpleMath.h"
+
+// Constants
+constexpr float epsilon = 1e-5f;
+constexpr DirectX::SimpleMath::Vector2 VEC2_ZERO = DirectX::SimpleMath::Vector2(0.0f, 0.0f);
+constexpr DirectX::SimpleMath::Vector2 VEC2_ONE = DirectX::SimpleMath::Vector2(1.0f, 1.0f);
+// NOTE: 1m 당 픽셀 스케일. 값이 바뀌면 전체 물리 체감이 변경
+constexpr float PTM_RATIO = 50.0f;

--- a/ProjectArenaDungeon/GameInstance.cpp
+++ b/ProjectArenaDungeon/GameInstance.cpp
@@ -28,6 +28,7 @@ void GameInstance::Init()
 	{
 		currentSceneIndex = 0;
 		currentScene = sceneList[currentSceneIndex];
+		PHYSICS.Init();
 		currentScene->Init();
 	}
 }
@@ -43,7 +44,14 @@ void GameInstance::Update()
 	//if (INPUT.GetKeyPress(VK_F5)) RequestSceneChange(currentSceneIndex, true);
 
 	if (currentScene)
+	{
 		currentScene->Update();
+
+		if (currentScene->UsesPhysics())
+		{
+			PHYSICS.Update();
+		}
+	}
 
 	ApplySceneChange();
 }
@@ -86,6 +94,7 @@ void GameInstance::ApplySceneChange()
 	if (currentScene)
 	{
 		currentScene->Destroy();
+		PHYSICS.Destroy();
 	}
 
 	// ¾À ±³Ã¼
@@ -99,6 +108,7 @@ void GameInstance::ApplySceneChange()
 	// »õ ¾À ÃÊ±âÈ­
 	if (currentScene)
 	{
+		PHYSICS.Init();
 		currentScene->Init();
 	}
 }

--- a/ProjectArenaDungeon/Managers/PhysicsManager.cpp
+++ b/ProjectArenaDungeon/Managers/PhysicsManager.cpp
@@ -1,0 +1,124 @@
+#include "pch.h"
+#include "PhysicsManager.h"
+
+//#include "Components/Collider.h"
+#include "Objects/Object.h"
+
+using Vector2 = DirectX::SimpleMath::Vector2;
+
+PhysicsManager::PhysicsManager() {}
+
+void PhysicsManager::Init()
+{
+	if (b2World_IsValid(worldId))
+	{
+		Destroy();
+	}
+
+	b2WorldDef worldDef = b2DefaultWorldDef();
+
+	// NOTE: 탑다운 기본은 중력 미사용.
+	worldDef.gravity = { 0.0f, 0.0f };
+
+	worldId = b2CreateWorld(&worldDef);
+}
+
+void PhysicsManager::Destroy()
+{
+	if (b2World_IsValid(worldId))
+	{
+		b2DestroyWorld(worldId);
+		worldId = b2_nullWorldId;
+	}
+
+	accumulator = 0.0f;
+}
+
+void PhysicsManager::Update()
+{
+	if (!b2World_IsValid(worldId))
+		return;
+
+	float dt = TIME.GetDeltaTime();
+
+	// NOTE: 프레임 드랍 시 폭주 방지.
+	if (dt > 0.25f)
+		dt = 0.25f;
+
+	accumulator += dt;
+
+	while (accumulator >= stepSize)
+	{
+		b2World_Step(worldId, stepSize * timeScale, subStepCount);
+
+		ProcessEvents();
+
+		accumulator -= stepSize;
+	}
+}
+
+void PhysicsManager::SetGravity(Vector2 gravity)
+{
+	if (!b2World_IsValid(worldId))
+		return;
+
+	b2World_SetGravity(worldId, { gravity.x, gravity.y });
+}
+
+void PhysicsManager::ProcessEvents()
+{
+	// NOTE: Sensor 이벤트 처리
+	// - Collider 컴포넌트 생성까지 빌드 오류 방지를 위해 임시 주석 처리
+	//const b2SensorEvents sEvents = b2World_GetSensorEvents(worldId);
+	//
+	//auto HandleSensor = [](b2ShapeId sensorId, b2ShapeId visitorId, bool isBegin)
+	//	{
+	//		if (!b2Shape_IsValid(sensorId) || !b2Shape_IsValid(visitorId))
+	//			return;
+	//
+	//		auto* colSensor = static_cast<Collider*>(b2Shape_GetUserData(sensorId));
+	//		auto* colVisitor = static_cast<Collider*>(b2Shape_GetUserData(visitorId));
+	//
+	//		if (!colSensor || !colVisitor)
+	//			return;
+	//
+	//		if (auto* owner = colSensor->GetOwner())
+	//			isBegin ? owner->OnCollisionEnter(colVisitor) : owner->OnCollisionExit(colVisitor);
+	//
+	//		if (auto* visitor = colVisitor->GetOwner())
+	//			isBegin ? visitor->OnCollisionEnter(colSensor) : visitor->OnCollisionExit(colSensor);
+	//	};
+	//
+	//for (int i = 0; i < sEvents.beginCount; ++i)
+	//	HandleSensor(sEvents.beginEvents[i].sensorShapeId, sEvents.beginEvents[i].visitorShapeId, true);
+	//
+	//for (int i = 0; i < sEvents.endCount; ++i)
+	//	HandleSensor(sEvents.endEvents[i].sensorShapeId, sEvents.endEvents[i].visitorShapeId, false);
+	//
+	//// NOTE: Contact 이벤트 처리
+	//const b2ContactEvents cEvents = b2World_GetContactEvents(worldId);
+	//
+	//auto HandleContact = [](b2ShapeId idA, b2ShapeId idB, bool isBegin)
+	//	{
+	//		if (!b2Shape_IsValid(idA) || !b2Shape_IsValid(idB))
+	//			return;
+	//
+	//		auto* colA = static_cast<Collider*>(b2Shape_GetUserData(idA));
+	//		auto* colB = static_cast<Collider*>(b2Shape_GetUserData(idB));
+	//
+	//		if (!colA || !colB)
+	//			return;
+	//
+	//		if (auto* ownerA = colA->GetOwner())
+	//			isBegin ? ownerA->OnCollisionEnter(colB) : ownerA->OnCollisionExit(colB);
+	//
+	//		if (auto* ownerB = colB->GetOwner())
+	//			isBegin ? ownerB->OnCollisionEnter(colA) : ownerB->OnCollisionExit(colA);
+	//	};
+	//
+	//for (int i = 0; i < cEvents.beginCount; ++i)
+	//	HandleContact(cEvents.beginEvents[i].shapeIdA, cEvents.beginEvents[i].shapeIdB, true);
+	//
+	//for (int i = 0; i < cEvents.endCount; ++i)
+	//	HandleContact(cEvents.endEvents[i].shapeIdA, cEvents.endEvents[i].shapeIdB, false);
+}

--- a/ProjectArenaDungeon/Managers/PhysicsManager.h
+++ b/ProjectArenaDungeon/Managers/PhysicsManager.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <cstdint>
+
+// Box2D
+#include <box2d/box2d.h>
+
+#include "_Libraries/DirectXTK/SimpleMath.h"
+
+// PhysicsManager
+// - Box2D 물리 월드를 생성/갱신하고, 센서/접촉 이벤트를 오브젝트로 전파
+// - 고정 스텝 기반으로 Step을 수행
+class PhysicsManager
+{
+	DECLARE_SINGLETON(PhysicsManager);
+
+public:
+	// Init
+	// - 물리 월드를 생성하고 기본 파라미터(중력/스텝)를 초기화
+	void Init();
+
+	// Destroy
+	// - 물리 월드를 해제
+	void Destroy();
+
+	// Update
+	// - 고정 스텝으로 Box2D Step을 수행하고 이벤트를 처리
+	void Update();
+
+	b2WorldId GetWorldId() const { return worldId; }
+
+	// SetGravity
+	// - 월드 중력을 설정
+	// - 탑다운 기본은 (0,0)으로 고정이며, 연출이나 이후 필요할 수 있는 상황에 대응한다.
+	void SetGravity(DirectX::SimpleMath::Vector2 gravity);
+
+private:
+	// ProcessEvents
+	// - Step 결과로 발생한 센서/접촉 이벤트를 Object의 충돌 이벤트로 전파
+	void ProcessEvents();
+
+private:
+	b2WorldId worldId = b2_nullWorldId;
+
+	float timeScale = 1.0f;
+	int subStepCount = 4;
+
+	float stepSize = 1.0f / 60.0f;
+	float accumulator = 0.0f;
+};

--- a/ProjectArenaDungeon/Objects/Object.h
+++ b/ProjectArenaDungeon/Objects/Object.h
@@ -1,9 +1,10 @@
 #pragma once
-
 #include <string>
 #include <memory>
 #include <unordered_map>
 #include <vector>
+
+#include "Config/ConstantValues.h"
 
 class Component;
 class Transform;

--- a/ProjectArenaDungeon/ProjectArenaDungeon.vcxproj
+++ b/ProjectArenaDungeon/ProjectArenaDungeon.vcxproj
@@ -150,11 +150,13 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="Components\Components.cpp" />
+    <ClCompile Include="Components\RigidBody.cpp" />
     <ClCompile Include="Components\Transform.cpp" />
     <ClCompile Include="GameInstance.cpp" />
     <ClCompile Include="Main.cpp" />
     <ClCompile Include="Managers\GraphicsManager.cpp" />
     <ClCompile Include="Managers\InputManager.cpp" />
+    <ClCompile Include="Managers\PhysicsManager.cpp" />
     <ClCompile Include="Managers\ShaderManager.cpp" />
     <ClCompile Include="Managers\TextureManager.cpp" />
     <ClCompile Include="Managers\TimeManager.cpp" />
@@ -177,10 +179,13 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Components\Component.h" />
+    <ClInclude Include="Components\RigidBody.h" />
     <ClInclude Include="Components\Transform.h" />
+    <ClInclude Include="Config\ConstantValues.h" />
     <ClInclude Include="GameInstance.h" />
     <ClInclude Include="Managers\GraphicsManager.h" />
     <ClInclude Include="Managers\InputManager.h" />
+    <ClInclude Include="Managers\PhysicsManager.h" />
     <ClInclude Include="Managers\ShaderManager.h" />
     <ClInclude Include="Managers\TextureManager.h" />
     <ClInclude Include="Managers\TimeManager.h" />
@@ -202,6 +207,7 @@
     <ClInclude Include="Scenes\SceneList.h" />
     <ClInclude Include="Scenes\TestScenes\Scene_TestFeature.h" />
     <ClInclude Include="targetver.h" />
+    <ClInclude Include="Utilities\PhysicsUtility.h" />
     <ClInclude Include="Window.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/ProjectArenaDungeon/ProjectArenaDungeon.vcxproj.filters
+++ b/ProjectArenaDungeon/ProjectArenaDungeon.vcxproj.filters
@@ -31,6 +31,12 @@
     <Filter Include="Scenes\TestScenes">
       <UniqueIdentifier>{2c8525f5-278f-48b3-a9b4-db24a364520c}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Config">
+      <UniqueIdentifier>{ff82a3dc-fc92-4783-ac35-1cbfe788daa1}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Utilities">
+      <UniqueIdentifier>{edca8346-5807-4e52-b157-984bdc0d44c5}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Main.cpp" />
@@ -93,6 +99,12 @@
     </ClCompile>
     <ClCompile Include="Scenes\TestScenes\Scene_TestFeature.cpp">
       <Filter>Scenes\TestScenes</Filter>
+    </ClCompile>
+    <ClCompile Include="Components\RigidBody.cpp">
+      <Filter>Components</Filter>
+    </ClCompile>
+    <ClCompile Include="Managers\PhysicsManager.cpp">
+      <Filter>Managers</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -168,6 +180,18 @@
     </ClInclude>
     <ClInclude Include="Scenes\SceneList.h">
       <Filter>Scenes</Filter>
+    </ClInclude>
+    <ClInclude Include="Components\RigidBody.h">
+      <Filter>Components</Filter>
+    </ClInclude>
+    <ClInclude Include="Config\ConstantValues.h">
+      <Filter>Config</Filter>
+    </ClInclude>
+    <ClInclude Include="Managers\PhysicsManager.h">
+      <Filter>Managers</Filter>
+    </ClInclude>
+    <ClInclude Include="Utilities\PhysicsUtility.h">
+      <Filter>Utilities</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/ProjectArenaDungeon/Scenes/Scene.h
+++ b/ProjectArenaDungeon/Scenes/Scene.h
@@ -39,6 +39,10 @@ public:
 			object->Render();
 	}
 
+	// UsesPhysics
+	// - 물리 세계를 적용할 씬은 override 해서 반환값을 true로 사용
+	virtual bool UsesPhysics() const { return false; }
+
 	// AddObject
 	// - 씬에 Object 추가
 	void AddObject(std::shared_ptr<Object> object)

--- a/ProjectArenaDungeon/Utilities/PhysicsUtility.h
+++ b/ProjectArenaDungeon/Utilities/PhysicsUtility.h
@@ -34,7 +34,7 @@ inline std::uint32_t operator|(std::uint32_t a, CollisionLayer b)
 	return a | static_cast<std::uint32_t>(b);
 }
 
-namespace PhysicsUtils
+namespace PhysicsUtility
 {
 // ScreenToWorld
 // - 화면 좌표(픽셀)를 물리 좌표(미터)로 변환

--- a/ProjectArenaDungeon/Utilities/PhysicsUtility.h
+++ b/ProjectArenaDungeon/Utilities/PhysicsUtility.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <cstdint>
+
+// Box2D
+#include <box2d/box2d.h>
+
+// DirectXTK SimpleMath
+#include "_Libraries/DirectXTK/SimpleMath.h"
+
+#include "Config/ConstantValues.h"
+
+// CollisionLayer
+// - Box2D 필터(categoryBits/maskBits)에 사용하는 충돌 레이어 정의
+// - Environment는 본 프로젝트에서 벽으로 대표되는 고정 오브젝트 등 월드 정적 요소
+enum class CollisionLayer : std::uint32_t
+{
+	Default = 0x0001,
+	Environment = 0x0002,
+	Player = 0x0004,
+	Enemy = 0x0008,
+	Bullet = 0x0010,
+	UI = 0x0020,
+};
+
+// operator | 오버로딩
+inline std::uint32_t operator|(CollisionLayer a, CollisionLayer b)
+{
+	return static_cast<std::uint32_t>(a) | static_cast<std::uint32_t>(b);
+}
+
+inline std::uint32_t operator|(std::uint32_t a, CollisionLayer b)
+{
+	return a | static_cast<std::uint32_t>(b);
+}
+
+namespace PhysicsUtils
+{
+// ScreenToWorld
+// - 화면 좌표(픽셀)를 물리 좌표(미터)로 변환
+inline b2Vec2 ScreenToWorld(const DirectX::SimpleMath::Vector2& screenPos)
+{
+	return b2Vec2{ screenPos.x / PTM_RATIO, screenPos.y / PTM_RATIO };
+}
+
+// WorldToScreen
+// - 물리 좌표(미터)를 화면 좌표(픽셀)로 변환
+inline DirectX::SimpleMath::Vector2 WorldToScreen(const b2Vec2& worldPos)
+{
+	return DirectX::SimpleMath::Vector2{ worldPos.x * PTM_RATIO, worldPos.y * PTM_RATIO };
+}
+}

--- a/ProjectArenaDungeon/pch.h
+++ b/ProjectArenaDungeon/pch.h
@@ -56,11 +56,6 @@ extern HWND gHandle;
 extern float gWinWidth;
 extern float gWinHeight;
 
-// Constants
-constexpr float epsilon = 1e-5f;
-constexpr DirectX::SimpleMath::Vector2 VEC2_ZERO = DirectX::SimpleMath::Vector2(0.0f, 0.0f);
-constexpr DirectX::SimpleMath::Vector2 VEC2_ONE = DirectX::SimpleMath::Vector2(1.0f, 1.0f);
-
 // Window default size
 #define WIN_DEFAULT_WIDTH 1280
 #define WIN_DEFAULT_HEIGHT 720
@@ -98,14 +93,15 @@ static CLASS_NAME& GetInstance()								\
 #include "Managers/GraphicsManager.h"
 #include "Managers/ShaderManager.h"
 #include "Managers/TextureManager.h"
+#include "Managers/PhysicsManager.h"
 
 // Manager access macros
 // - 반복되는 접근 코드를 간결하게 사용하기 위한 편의성 매크로
 #define TIME TimeManager::GetInstance()
-#define DELTA TIME.GetDeltaTime()
 #define INPUT InputManager::GetInstance()
 #define GRAPHICS GraphicsManager::GetInstance()
 #define DEVICE GRAPHICS.GetDevice()
 #define DEVICE_CONTEXT GRAPHICS.GetDeviceContext()
 #define SHADERS ShaderManager::GetInstance()
 #define TEXTURES TextureManager::GetInstance()
+#define PHYSICS PhysicsManager::GetInstance()


### PR DESCRIPTION
## Overview

Box2D 기반 물리 세계(PhysicsManager)를 도입하고, RigidBody 컴포넌트를 통해 Transform과 물리 월드를 동기화 하는 구조를 구축합니다.

---

## Changes

PhysicsManager 추가
- Box2D 월드 생성 / 해제 / 갱신 담당
- 고정 스텝 기반 처리 구조 적용
- 시간 누적으로 인한 폭주 방지 로직 적용
- Sensor / Contact 이벤트를 Object의 OnCollisionEnter/Exit로 전파하는 흐름 구성
- 탑다운 뷰 기준 중력 (0, 0) 설정 및 이후 확장 상황을 위한 SetGravity() 인터페이스 추가

Scene / GameInstance
- GameInstance에서 Scene의 Init / Destroy / Update와 PhysicsManager 연계
- Scene에 UsesPhysics() 함수를 추가하여 물리 사용 여부에 따라 물리 세계 조건부 갱신
- 씬 전환 시 물리 월드 초기화 / 해제 적용

PhysicsUtility 작성
- 픽셀과 미터 단위 변환 (ScreenToWorld / WorldToScreen) 구현
- Box2D 필터와 연계할 CollisionLayer 정의
  - Default / Environment(벽, 이후 확장 가능한 static 오브젝트) / Player / Enemy(일반 적, 보스) / Bullet / UI
- 레이어 조합을 위한 | 연산자 오버로딩

RigidBody 컴포넌트 추가
- Transform 기준으로 Box2D 바디 생성
- BodyType(Static / Dynamic / Kinematic)에 따라 바디 생성
- 픽셀/미터 변환을 통해 위치 및 속도를 월드에 반영
- 물리 Step 결과를 Transform과 동기화
- damping / fixedRotation 옵션 제어 함수 추가

코드 정리
- pch 매크로 정리
  - PhysicsManager 접근 매크로 추가
  - DELTA 매크로 제거 ( Closes #7 )
  - 상수식 ConstantValues.h로 분리
- ConstantValues.h 도입에 따라 기존 상수식 사용 클래스에 포함

---

## Purpose

- 게임 루프에 물리 세계(Box2D)를 통합하여 실제 전투/캐릭터 구현 기반 생성
- Transform 중심 구조에 물리(RigidBody)를 연결
- 이후 Collider / DamageSystem / 전투 로직 확장을 위한 구조 확보

---

## How to Test

1. 디버그 모드로 빌드
2. 추가된 클래스에 대해 컴파일 에러 및 경고 여부 확인
3. 디버그 전용 콘솔창 출력을 이용해 테스트 씬에 RigidBody 컴포넌트를 부착한 오브젝트의 로드 확인

---

## Notes

- 이후 테스트 씬 추가(Battle)로 씬 전환 동작 확인 필요
- Sensor / Contact 이벤트 전파 구조는 Collider 컴포넌트 추가 이후 활성화 예정
- 씬 단위 물리 월드 리셋 정책에 대해 진행 사항에 따라 변경 가능
- CollisionLayer는 최소 구조로 정의, 이후 필요에 의해 확장 가능