### PR TITLE
feat: Collider - BoxCollider / CircleCollider 컴포넌트 추가

### DIFF
--- a/ProjectArenaDungeon/Components/BoxCollider.cpp
+++ b/ProjectArenaDungeon/Components/BoxCollider.cpp
@@ -1,0 +1,53 @@
+#include "pch.h"
+#include "Components/BoxCollider.h"
+
+#include <cmath>
+#include "Config/ConstantValues.h"
+
+#include "Objects/Object.h"
+
+#include "Components/Transform.h"
+
+#include "Utilities/PhysicsUtility.h"
+
+using Vector2 = DirectX::SimpleMath::Vector2;
+
+BoxCollider::BoxCollider(std::string name)
+	: Collider(std::move(name))
+{
+}
+
+bool BoxCollider::IsColliding(Vector2 point)
+{
+	if (!owner)
+		return false;
+
+	const auto* tr = owner->GetTransform();
+	if (!tr)
+		return false;
+
+	const Vector2 scale = tr->GetScale();
+
+	const Vector2 center =
+		tr->GetPosition()
+		+ tr->GetRight() * GetOffset().x
+		+ tr->GetUp() * GetOffset().y;
+
+	const Vector2 dist = point - center;
+
+	const Vector2 localPoint(dist.Dot(tr->GetRight()), dist.Dot(tr->GetUp()));
+	const Vector2 halfScale(std::abs(scale.x) * 0.5f, std::abs(scale.y) * 0.5f);
+
+	return (std::abs(localPoint.x) <= halfScale.x) && (std::abs(localPoint.y) <= halfScale.y);
+}
+
+b2ShapeId BoxCollider::CreateShapeInternal(b2BodyId bodyId, const b2ShapeDef& def, Vector2 ownerScale)
+{
+	const float hx = (std::abs(ownerScale.x) * 0.5f) / PTM_RATIO;
+	const float hy = (std::abs(ownerScale.y) * 0.5f) / PTM_RATIO;
+
+	const b2Vec2 center = PhysicsUtility::ScreenToWorld(GetOffset());
+	const b2Polygon box = b2MakeOffsetBox(hx, hy, center, b2MakeRot(0.0f));
+
+	return b2CreatePolygonShape(bodyId, &def, &box);
+}

--- a/ProjectArenaDungeon/Components/BoxCollider.h
+++ b/ProjectArenaDungeon/Components/BoxCollider.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "Components/Collider.h"
+
+// BoxCollider
+// - Box2D polygon(box) shape를 생성하는 콜라이더
+// - 점 판정 기능 구현
+class BoxCollider final : public Collider
+{
+public:
+	explicit BoxCollider(std::string name = "BoxCollider");
+
+	// IsColliding
+	// - Transform 기준 OBB 공간에서 점 포함 여부를 판정
+	bool IsColliding(DirectX::SimpleMath::Vector2 point) override;
+
+protected:
+	// CreateShapeInternal
+	// - body에 offset box shape를 생성하여 부착
+	b2ShapeId CreateShapeInternal(
+		b2BodyId bodyId,
+		const b2ShapeDef& def,
+		DirectX::SimpleMath::Vector2 ownerScale
+	) override;
+};

--- a/ProjectArenaDungeon/Components/CircleCollider.cpp
+++ b/ProjectArenaDungeon/Components/CircleCollider.cpp
@@ -1,0 +1,54 @@
+#include "pch.h"
+#include "Components/CircleCollider.h"
+
+#include <algorithm>
+#include <cmath>
+#include "Config/ConstantValues.h"
+
+#include "Objects/Object.h"
+
+#include "Components/Transform.h"
+
+#include "Utilities/PhysicsUtility.h"
+
+using Vector2 = DirectX::SimpleMath::Vector2;
+
+CircleCollider::CircleCollider(std::string name)
+	: Collider(std::move(name))
+{
+}
+
+bool CircleCollider::IsColliding(Vector2 point)
+{
+	auto* ownerObj = GetOwner();
+	if (!ownerObj) return false;
+
+	const auto* tr = ownerObj->GetTransform();
+	if (!tr) return false;
+
+	const Vector2 center =
+		tr->GetPosition()
+		+ tr->GetRight() * GetOffset().x
+		+ tr->GetUp() * GetOffset().y;
+
+	const auto scale = tr->GetScale();
+
+	// NOTE: 원 반지름은 scale의 큰 축 기준(픽셀 단위)으로 계산한다.
+	const float radius = std::max(std::abs(scale.x), std::abs(scale.y)) * 0.5f;
+
+	const auto delta = point - center;
+	const float distSq = delta.LengthSquared();
+	const float radiusSq = radius * radius;
+
+	return distSq < radiusSq;
+}
+
+b2ShapeId CircleCollider::CreateShapeInternal(b2BodyId bodyId, const b2ShapeDef& def, Vector2 ownerScale)
+{
+	const float radius = (std::max(std::abs(ownerScale.x), std::abs(ownerScale.y)) * 0.5f) / PTM_RATIO;
+
+	const b2Vec2 center = PhysicsUtility::ScreenToWorld(GetOffset());
+	const b2Circle circle{ center, radius };
+
+	return b2CreateCircleShape(bodyId, &def, &circle);
+}

--- a/ProjectArenaDungeon/Components/CircleCollider.h
+++ b/ProjectArenaDungeon/Components/CircleCollider.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "Components/Collider.h"
+
+// CircleCollider
+// - Box2D circle shape를 생성하는 콜라이더
+// - 점 판정 기능 구현
+class CircleCollider final : public Collider
+{
+public:
+	explicit CircleCollider(std::string name = "CircleCollider");
+
+	// IsColliding
+	// - Transform 기준 원(스케일 기반 반지름) 포함 여부를 판정
+	bool IsColliding(DirectX::SimpleMath::Vector2 point) override;
+
+protected:
+	// CreateShapeInternal
+	// - body에 offset circle shape를 생성하여 부착
+	b2ShapeId CreateShapeInternal(
+		b2BodyId bodyId,
+		const b2ShapeDef& def,
+		DirectX::SimpleMath::Vector2 ownerScale
+	) override;
+};

--- a/ProjectArenaDungeon/Components/Collider.cpp
+++ b/ProjectArenaDungeon/Components/Collider.cpp
@@ -1,0 +1,182 @@
+#include "pch.h"
+#include "Components/Collider.h"
+
+#include <cmath>
+#include "Config/ConstantValues.h"
+
+#include "Objects/Object.h"
+
+#include "Components/Transform.h"
+#include "Components/RigidBody.h"
+
+using Vector2 = DirectX::SimpleMath::Vector2;
+
+namespace
+{
+	constexpr float MIN_PIXEL_SIZE = 0.001f;
+}
+
+Collider::Collider(std::string name)
+	: Component(std::move(name))
+{
+}
+
+Collider::~Collider()
+{
+	if (b2Shape_IsValid(shapeId))
+	{
+		b2DestroyShape(shapeId, true);
+		shapeId = b2_nullShapeId;
+	}
+}
+
+void Collider::Awake()
+{
+	RefreshShape();
+}
+
+void Collider::Update()
+{
+	if (!owner)
+		return;
+
+	const auto* tr = owner->GetTransform();
+	if (!tr)
+		return;
+
+	const Vector2 currentScale = tr->GetScale();
+
+	// NOTE: DistanceSquared는 제곱 값이므로 epsilonSq로 비교한다.
+	if (Vector2::DistanceSquared(currentScale, lastScale) > epsilonSq)
+	{
+		RefreshShape();
+	}
+}
+
+void Collider::SetOffset(Vector2 value)
+{
+	if (offset != value)
+	{
+		offset = value;
+		RefreshShape();
+	}
+}
+
+void Collider::SetCollisionLayer(CollisionLayer value)
+{
+	if (layer == value)
+		return;
+
+	layer = value;
+	ApplyFilter();
+}
+
+void Collider::SetCollisionMask(uint32_t value)
+{
+	if (mask == value)
+		return;
+
+	mask = value;
+	ApplyFilter();
+}
+
+void Collider::SetIsSensor(bool value)
+{
+	if (isSensor == value)
+		return;
+
+	isSensor = value;
+	RefreshShape();
+}
+
+void Collider::RefreshShape()
+{
+	if (!owner)
+		return;
+
+	auto rb = owner->GetComponent<RigidBody>("RigidBody");
+	if (!rb || !b2Body_IsValid(rb->GetBodyId()))
+		return;
+
+	const auto* tr = owner->GetTransform();
+	if (!tr)
+		return;
+
+	const Vector2 scale = tr->GetScale();
+
+	// NOTE: 너무 작은 스케일은 제외한다.
+	if (std::abs(scale.x) < MIN_PIXEL_SIZE || std::abs(scale.y) < MIN_PIXEL_SIZE)
+		return;
+
+	if (b2Shape_IsValid(shapeId))
+	{
+		// NOTE: shape 파괴로 인해 겹침 상태가 해제될 수 있으므로,
+		//       기존 AABB와 겹치던 대상에게 Exit를 전파한 뒤 shape를 파괴한다.
+		const b2AABB aabb = b2Shape_GetAABB(shapeId);
+		b2World_OverlapAABB(PHYSICS.GetWorldId(), aabb, b2DefaultQueryFilter(), NotifyExitCallback, this);
+
+		b2DestroyShape(shapeId, true);
+		shapeId = b2_nullShapeId;
+	}
+
+	lastScale = scale;
+
+	b2ShapeDef def = b2DefaultShapeDef();
+	def.density = 1.0f;
+	def.material.friction = 0.5f;
+	def.material.restitution = 0.1f;
+
+	def.userData = this;
+
+	def.isSensor = isSensor;
+	def.enableSensorEvents = true;
+	if (!isSensor)
+	{
+		def.enableContactEvents = true;
+	}
+
+	def.filter.categoryBits = static_cast<uint32_t>(layer);
+	def.filter.maskBits = mask;
+
+	shapeId = CreateShapeInternal(rb->GetBodyId(), def, scale);
+
+	b2Body_SetAwake(rb->GetBodyId(), true);
+}
+
+bool Collider::NotifyExitCallback(b2ShapeId otherShapeId, void* context)
+{
+	auto* me = static_cast<Collider*>(context);
+	if (!me || !me->owner)
+		return true;
+
+	if (!b2Shape_IsValid(otherShapeId))
+		return true;
+
+	auto* other = static_cast<Collider*>(b2Shape_GetUserData(otherShapeId));
+	
+	if (!other)
+		return true;
+
+	// 상대에게 나를 알림
+	if (auto* otherOwner = other->GetOwner())
+		otherOwner->OnCollisionExit(me);
+
+	// 나에게도 상대를 알림
+	if (auto* myOwner = me->GetOwner())
+		myOwner->OnCollisionExit(other);
+
+	return true;
+}
+
+void Collider::ApplyFilter() const
+{
+	if (!b2Shape_IsValid(shapeId))
+		return;
+
+	b2Filter filter = b2DefaultFilter();
+	filter.categoryBits = static_cast<uint32_t>(layer);
+	filter.maskBits = mask;
+	filter.groupIndex = 0;
+
+	b2Shape_SetFilter(shapeId, filter);
+}

--- a/ProjectArenaDungeon/Components/Collider.h
+++ b/ProjectArenaDungeon/Components/Collider.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <cstdint>
+
+#include <box2d/box2d.h>
+#include "_Libraries/DirectXTK/SimpleMath.h"
+
+#include "Components/Component.h"
+#include "Utilities/PhysicsUtility.h"
+
+// Collider
+// - Box2D shape를 RigidBody(body)에 부착하는 컴포넌트 기반 클래스
+// - scale/offset/sensor/filter 변경 시 shape를 재생성하여 동기화
+class Collider : public Component
+{
+public:
+	explicit Collider(std::string name = "Collider");
+	~Collider() override;
+
+	// Awake
+	// - 현재 Transform/RigidBody 상태를 기준으로 shape를 생성
+	void Awake() override;
+
+	// Update
+	// - Transform scale 변화가 감지되면 shape를 갱신
+	void Update() override;
+
+	// IsColliding
+	// - 점 기반 충돌 판정
+	virtual bool IsColliding(DirectX::SimpleMath::Vector2 point) = 0;
+
+	// SetOffset
+	// - body 로컬 공간에서 shape 중심 오프셋(픽셀 단위)
+	// - 값 변경 시 shape를 재생성
+	void SetOffset(DirectX::SimpleMath::Vector2 value);
+
+	DirectX::SimpleMath::Vector2 GetOffset() const { return offset; }
+
+	// SetCollisionLayer / SetCollisionMask
+	// - Box2D 필터(category/mask)를 설정
+	// - shape가 이미 존재하면 필터를 반영
+	void SetCollisionLayer(CollisionLayer value);
+	void SetCollisionMask(uint32_t value);
+
+	// SetIsSensor
+	// - sensor 여부를 변경
+	// - shape 생성 시 세팅 전용으로 사용
+	void SetIsSensor(bool value);
+
+	bool IsSensor() const { return isSensor; }
+
+	b2ShapeId GetShapeId() const { return shapeId; }
+
+protected:
+	// CreateShapeInternal
+	// - 파생 클래스가 도형 형태(box/circle 등)를 구성하고 shape를 생성
+	virtual b2ShapeId CreateShapeInternal(
+		b2BodyId bodyId,
+		const b2ShapeDef& def,
+		DirectX::SimpleMath::Vector2 ownerScale
+	) = 0;
+
+	// RefreshShape
+	// - 현재 Transform/RigidBody/필터/센서 설정을 기준으로 shape를 재생성
+	void RefreshShape();
+
+	// ApplyFilter
+	// - 현재 layer/mask를 기존 shape에 반영
+	void ApplyFilter() const;
+
+	// NotifyExitCallback
+	// - shape 파괴 직전, 기존 AABB와 겹치던 대상에게 Exit를 전파하기 위한 콜백
+	static bool NotifyExitCallback(b2ShapeId otherShapeId, void* context);
+
+protected:
+	b2ShapeId shapeId = b2_nullShapeId;
+
+	bool isSensor = false;
+
+	DirectX::SimpleMath::Vector2 offset = DirectX::SimpleMath::Vector2(0.0f, 0.0f);
+	DirectX::SimpleMath::Vector2 lastScale = DirectX::SimpleMath::Vector2(-999.0f, -999.0f);
+
+	CollisionLayer layer = CollisionLayer::Default;
+	uint32_t mask = 0xFFFFFFFF;
+};

--- a/ProjectArenaDungeon/Components/Transform.cpp
+++ b/ProjectArenaDungeon/Components/Transform.cpp
@@ -7,8 +7,6 @@
 using Vector2 = DirectX::SimpleMath::Vector2;
 using Matrix = DirectX::SimpleMath::Matrix;
 
-constexpr float epsilonSq = epsilon * epsilon;
-
 Transform::Transform(std::string name)
 	: Component(std::move(name))
 {

--- a/ProjectArenaDungeon/Config/ConstantValues.h
+++ b/ProjectArenaDungeon/Config/ConstantValues.h
@@ -4,6 +4,7 @@
 
 // Constants
 constexpr float epsilon = 1e-5f;
+constexpr float epsilonSq = epsilon * epsilon;
 constexpr DirectX::SimpleMath::Vector2 VEC2_ZERO = DirectX::SimpleMath::Vector2(0.0f, 0.0f);
 constexpr DirectX::SimpleMath::Vector2 VEC2_ONE = DirectX::SimpleMath::Vector2(1.0f, 1.0f);
 // NOTE: 1m 당 픽셀 스케일. 값이 바뀌면 전체 물리 체감이 변경

--- a/ProjectArenaDungeon/Managers/PhysicsManager.cpp
+++ b/ProjectArenaDungeon/Managers/PhysicsManager.cpp
@@ -1,8 +1,9 @@
 #include "pch.h"
 #include "PhysicsManager.h"
 
-//#include "Components/Collider.h"
 #include "Objects/Object.h"
+
+#include "Components/Collider.h"
 
 using Vector2 = DirectX::SimpleMath::Vector2;
 
@@ -68,57 +69,56 @@ void PhysicsManager::SetGravity(Vector2 gravity)
 void PhysicsManager::ProcessEvents()
 {
 	// NOTE: Sensor 이벤트 처리
-	// - Collider 컴포넌트 생성까지 빌드 오류 방지를 위해 임시 주석 처리
-	//const b2SensorEvents sEvents = b2World_GetSensorEvents(worldId);
-	//
-	//auto HandleSensor = [](b2ShapeId sensorId, b2ShapeId visitorId, bool isBegin)
-	//	{
-	//		if (!b2Shape_IsValid(sensorId) || !b2Shape_IsValid(visitorId))
-	//			return;
-	//
-	//		auto* colSensor = static_cast<Collider*>(b2Shape_GetUserData(sensorId));
-	//		auto* colVisitor = static_cast<Collider*>(b2Shape_GetUserData(visitorId));
-	//
-	//		if (!colSensor || !colVisitor)
-	//			return;
-	//
-	//		if (auto* owner = colSensor->GetOwner())
-	//			isBegin ? owner->OnCollisionEnter(colVisitor) : owner->OnCollisionExit(colVisitor);
-	//
-	//		if (auto* visitor = colVisitor->GetOwner())
-	//			isBegin ? visitor->OnCollisionEnter(colSensor) : visitor->OnCollisionExit(colSensor);
-	//	};
-	//
-	//for (int i = 0; i < sEvents.beginCount; ++i)
-	//	HandleSensor(sEvents.beginEvents[i].sensorShapeId, sEvents.beginEvents[i].visitorShapeId, true);
-	//
-	//for (int i = 0; i < sEvents.endCount; ++i)
-	//	HandleSensor(sEvents.endEvents[i].sensorShapeId, sEvents.endEvents[i].visitorShapeId, false);
-	//
-	//// NOTE: Contact 이벤트 처리
-	//const b2ContactEvents cEvents = b2World_GetContactEvents(worldId);
-	//
-	//auto HandleContact = [](b2ShapeId idA, b2ShapeId idB, bool isBegin)
-	//	{
-	//		if (!b2Shape_IsValid(idA) || !b2Shape_IsValid(idB))
-	//			return;
-	//
-	//		auto* colA = static_cast<Collider*>(b2Shape_GetUserData(idA));
-	//		auto* colB = static_cast<Collider*>(b2Shape_GetUserData(idB));
-	//
-	//		if (!colA || !colB)
-	//			return;
-	//
-	//		if (auto* ownerA = colA->GetOwner())
-	//			isBegin ? ownerA->OnCollisionEnter(colB) : ownerA->OnCollisionExit(colB);
-	//
-	//		if (auto* ownerB = colB->GetOwner())
-	//			isBegin ? ownerB->OnCollisionEnter(colA) : ownerB->OnCollisionExit(colA);
-	//	};
-	//
-	//for (int i = 0; i < cEvents.beginCount; ++i)
-	//	HandleContact(cEvents.beginEvents[i].shapeIdA, cEvents.beginEvents[i].shapeIdB, true);
-	//
-	//for (int i = 0; i < cEvents.endCount; ++i)
-	//	HandleContact(cEvents.endEvents[i].shapeIdA, cEvents.endEvents[i].shapeIdB, false);
+	const b2SensorEvents sEvents = b2World_GetSensorEvents(worldId);
+	
+	auto HandleSensor = [](b2ShapeId sensorId, b2ShapeId visitorId, bool isBegin)
+		{
+			if (!b2Shape_IsValid(sensorId) || !b2Shape_IsValid(visitorId))
+				return;
+	
+			auto* colSensor = static_cast<Collider*>(b2Shape_GetUserData(sensorId));
+			auto* colVisitor = static_cast<Collider*>(b2Shape_GetUserData(visitorId));
+	
+			if (!colSensor || !colVisitor)
+				return;
+	
+			if (auto* owner = colSensor->GetOwner())
+				isBegin ? owner->OnCollisionEnter(colVisitor) : owner->OnCollisionExit(colVisitor);
+	
+			if (auto* visitor = colVisitor->GetOwner())
+				isBegin ? visitor->OnCollisionEnter(colSensor) : visitor->OnCollisionExit(colSensor);
+		};
+	
+	for (int i = 0; i < sEvents.beginCount; ++i)
+		HandleSensor(sEvents.beginEvents[i].sensorShapeId, sEvents.beginEvents[i].visitorShapeId, true);
+	
+	for (int i = 0; i < sEvents.endCount; ++i)
+		HandleSensor(sEvents.endEvents[i].sensorShapeId, sEvents.endEvents[i].visitorShapeId, false);
+	
+	// NOTE: Contact 이벤트 처리
+	const b2ContactEvents cEvents = b2World_GetContactEvents(worldId);
+	
+	auto HandleContact = [](b2ShapeId idA, b2ShapeId idB, bool isBegin)
+		{
+			if (!b2Shape_IsValid(idA) || !b2Shape_IsValid(idB))
+				return;
+	
+			auto* colA = static_cast<Collider*>(b2Shape_GetUserData(idA));
+			auto* colB = static_cast<Collider*>(b2Shape_GetUserData(idB));
+	
+			if (!colA || !colB)
+				return;
+	
+			if (auto* ownerA = colA->GetOwner())
+				isBegin ? ownerA->OnCollisionEnter(colB) : ownerA->OnCollisionExit(colB);
+	
+			if (auto* ownerB = colB->GetOwner())
+				isBegin ? ownerB->OnCollisionEnter(colA) : ownerB->OnCollisionExit(colA);
+		};
+	
+	for (int i = 0; i < cEvents.beginCount; ++i)
+		HandleContact(cEvents.beginEvents[i].shapeIdA, cEvents.beginEvents[i].shapeIdB, true);
+	
+	for (int i = 0; i < cEvents.endCount; ++i)
+		HandleContact(cEvents.endEvents[i].shapeIdA, cEvents.endEvents[i].shapeIdB, false);
 }

--- a/ProjectArenaDungeon/Objects/Object.cpp
+++ b/ProjectArenaDungeon/Objects/Object.cpp
@@ -4,7 +4,7 @@
 // Components
 #include "Components/Component.h"
 #include "Components/Transform.h"
-//#include "Components/Collider.h"
+#include "Components/Collider.h"
 
 Object::Object(const std::string& name, DirectX::SimpleMath::Vector2 position, DirectX::SimpleMath::Vector2 scale, float rotation)
 	: name(name)
@@ -60,29 +60,29 @@ void Object::Render()
 	}
 }
 
-//void Object::OnCollisionEnter(Collider* other)
-//{
-//	if (!bActive)
-//		return;
-//
-//	for (const auto& component : updateList)
-//	{
-//		if (component)
-//			component->OnCollisionEnter(other);
-//	}
-//}
-//
-//void Object::OnCollisionExit(Collider* other)
-//{
-//	if (!bActive)
-//		return;
-//
-//	for (const auto& component : updateList)
-//	{
-//		if (component)
-//			component->OnCollisionExit(other);
-//	}
-//}
+void Object::OnCollisionEnter(Collider* other)
+{
+	if (!bActive)
+		return;
+
+	for (const auto& component : updateList)
+	{
+		if (component)
+			component->OnCollisionEnter(other);
+	}
+}
+
+void Object::OnCollisionExit(Collider* other)
+{
+	if (!bActive)
+		return;
+
+	for (const auto& component : updateList)
+	{
+		if (component)
+			component->OnCollisionExit(other);
+	}
+}
 
 void Object::AddComponent(const std::shared_ptr<Component>& component)
 {

--- a/ProjectArenaDungeon/Objects/Object.h
+++ b/ProjectArenaDungeon/Objects/Object.h
@@ -37,13 +37,13 @@ public:
 	// - 매 프레임 렌더링 호출
 	virtual void Render();
 
-	//// OnCollisionEnter
-	//// - 충돌 시작 시점 이벤트 전달
-	//virtual void OnCollisionEnter(Collider* other);
-	//
-	//// OnCollisionExit
-	//// - 충돌 종료 시점 이벤트 전달
-	//virtual void OnCollisionExit(Collider* other);
+	// OnCollisionEnter
+	// - 충돌 시작 시점 이벤트 전달
+	virtual void OnCollisionEnter(Collider* other);
+	
+	// OnCollisionExit
+	// - 충돌 종료 시점 이벤트 전달
+	virtual void OnCollisionExit(Collider* other);
 
 	// AddComponent
 	// - 컴포넌트를 오브젝트에 결합

--- a/ProjectArenaDungeon/ProjectArenaDungeon.vcxproj
+++ b/ProjectArenaDungeon/ProjectArenaDungeon.vcxproj
@@ -149,6 +149,9 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="Components\BoxCollider.cpp" />
+    <ClCompile Include="Components\CircleCollider.cpp" />
+    <ClCompile Include="Components\Collider.cpp" />
     <ClCompile Include="Components\Components.cpp" />
     <ClCompile Include="Components\RigidBody.cpp" />
     <ClCompile Include="Components\Transform.cpp" />
@@ -178,6 +181,9 @@
     <ClCompile Include="Window.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="Components\BoxCollider.h" />
+    <ClInclude Include="Components\CircleCollider.h" />
+    <ClInclude Include="Components\Collider.h" />
     <ClInclude Include="Components\Component.h" />
     <ClInclude Include="Components\RigidBody.h" />
     <ClInclude Include="Components\Transform.h" />

--- a/ProjectArenaDungeon/ProjectArenaDungeon.vcxproj.filters
+++ b/ProjectArenaDungeon/ProjectArenaDungeon.vcxproj.filters
@@ -106,6 +106,15 @@
     <ClCompile Include="Managers\PhysicsManager.cpp">
       <Filter>Managers</Filter>
     </ClCompile>
+    <ClCompile Include="Components\BoxCollider.cpp">
+      <Filter>Components</Filter>
+    </ClCompile>
+    <ClCompile Include="Components\CircleCollider.cpp">
+      <Filter>Components</Filter>
+    </ClCompile>
+    <ClCompile Include="Components\Collider.cpp">
+      <Filter>Components</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />
@@ -192,6 +201,15 @@
     </ClInclude>
     <ClInclude Include="Utilities\PhysicsUtility.h">
       <Filter>Utilities</Filter>
+    </ClInclude>
+    <ClInclude Include="Components\BoxCollider.h">
+      <Filter>Components</Filter>
+    </ClInclude>
+    <ClInclude Include="Components\CircleCollider.h">
+      <Filter>Components</Filter>
+    </ClInclude>
+    <ClInclude Include="Components\Collider.h">
+      <Filter>Components</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Overview
Collider 기반 클래스와 BoxCollider / CircleCollider를 구현하고, 기존 물리 이벤트 흐름을 활성화합니다.

---

## Changes

### Collider 기반 클래스 구현
- Box2D shape를 RigidBody(body)에 부착하는 Collider 컴포넌트 추가
- Transform scale / offset / sensor / filter 변경 시 shape 재생성 구조 구현
- scale 변화에 대해 RefreshShape로 동기화
- CollisionLayer / mask 기반 Box2D filter 연동
- CreateShapeInternal을 순수 가상 함수로 분리하여 파생 도형(Box/Circle) 확장 준비
- epsilonSq 기반 scale 변경 감지
- 최소 픽셀 크기(MIN_PIXEL_SIZE) 보호 처리

### Shape Lifecycle 정리
- 기존 shape 존재 시 AABB overlap 검사 후 Exit 이벤트 전파
- NotifyExitCallback에서 양방향(OnCollisionExit)으로 Exit 처리
- shape 파괴 후 재생성 구조 적용

### Sensor / Contact 처리
- shape 생성 시 isSensor 옵션 지원
- sensor/contact 이벤트 활성화 설정 분리
- ApplyFilter를 통해 필터 변경 반영

### BoxCollider / CircleCollider 구현
- BoxCollider
  - Transform 기준 OBB 점 포함 판정(IsColliding) 구현
  - Box2D offset box shape 생성(CreateShapeInternal)

- CircleCollider
  - Transform 기준 원 점 포함 판정(IsColliding) 구현
  - Box2D offset circle shape 생성(CreateShapeInternal)

### 관련 코드 활성화
- Object
  - Collider 포함 및 OnCollisionEnter / OnCollisionExit 활성화
- PhysicsManager
  - ProcessEvents 내부 Sensor / Contact 이벤트 처리 활성화

### 상수 정리
- epsilonSq 추가
- Transform에서 단독 사용하던 epsilon 제거 후 ConstantValues.h로 통합

---

## Purpose
- Box2D 기반 충돌 처리 구조를 완성하고, 게임 로직 계층에서 충돌 이벤트를 활용할 수 있는 기반 마련
- Collider 기반 클래스에서 도형 확장(Box / Circle) 구조 확립
- shape 재생성 및 Exit 정리 로직을 통해 물리 상태 일관성 확보
- 이후 전투 테스트 및 DamageSystem 확장을 위한 충돌 기반 구조 준비

---

## How to Test
1. 프로젝트를 디버그 모드로 빌드
2. 컴파일 에러 및 경고 여부 확인
3. 실행 시 물리 시스템 초기화 및 씬 로딩 정상 동작 확인
4. Collider / BoxCollider / CircleCollider 추가 후 링크 에러 및 빌드 실패가 없는지 확인

※ 실제 오브젝트 생성 및 충돌 동작 테스트는 이후 브랜치에서 테스트 씬 구성 후 진행 예정

---

## Notes
- 현재 PR은 구조 도입 단계이며, 실제 충돌 동작 검증은 다음 브랜치에서 테스트 씬을 통해 진행 예정
- NotifyExitCallback에서 양방향 Exit 정리를 수행하여 shape 재생성 시 상태 불일치 방지
- 충돌 레이어 및 필터 정책은 이후 전투 시스템 구현 시 세부 조정 가능