### PR TITLE
feat: MeshRenderer 컴포넌트 추가 및 테스트 씬 구성

### DIFF
--- a/ProjectArenaDungeon/Components/MeshRenderer.cpp
+++ b/ProjectArenaDungeon/Components/MeshRenderer.cpp
@@ -1,0 +1,28 @@
+#include "pch.h"
+#include "Components/MeshRenderer.h"
+
+#include "Resources/Mesh.h"
+#include "Resources/Material.h"
+
+MeshRenderer::MeshRenderer(std::string name)
+	: Component(std::move(name))
+{
+}
+
+void MeshRenderer::Render()
+{
+	// NOTE:
+	// - Mesh/Material이 없는 경우 렌더링을 수행하지 않는다.
+	if (!mesh || !material)
+		return;
+
+	const UINT indexCount = mesh->GetIndexCount();
+	if (indexCount == 0)
+		return;
+
+	mesh->Bind();
+	material->Bind();
+
+	DEVICE_CONTEXT->IASetPrimitiveTopology(topology);
+	DEVICE_CONTEXT->DrawIndexed(indexCount, 0, 0);
+}

--- a/ProjectArenaDungeon/Components/MeshRenderer.h
+++ b/ProjectArenaDungeon/Components/MeshRenderer.h
@@ -1,0 +1,1 @@
+#pragma once

--- a/ProjectArenaDungeon/Components/MeshRenderer.h
+++ b/ProjectArenaDungeon/Components/MeshRenderer.h
@@ -1,1 +1,40 @@
 #pragma once
+
+#include <memory>
+#include <string>
+
+// D3D11_PRIMITIVE_TOPOLOGY
+#include <d3d11.h>
+
+#include "Components/Component.h"
+
+class Mesh;
+class Material;
+
+// MeshRenderer
+// - Mesh + Material을 결합하여 렌더링을 수행하는 컴포넌트
+// - 현재는 MeshRenderer가 직접 DrawCall을 수행
+// - NOTE: 이후 Instancing 도입 시 RenderSystem으로 DrawCall 요청 구조로 이관 예정
+class MeshRenderer final : public Component
+{
+public:
+	explicit MeshRenderer(std::string name = "MeshRenderer");
+	~MeshRenderer() override = default;
+
+	// Render
+	// - Mesh/Material이 준비된 경우에만 파이프라인에 바인딩 후 DrawIndexed 수행
+	void Render() override;
+
+	void SetMesh(std::shared_ptr<Mesh> value) { mesh = std::move(value); }
+	void SetMaterial(std::shared_ptr<Material> value) { material = std::move(value); }
+
+	void SetTopology(D3D11_PRIMITIVE_TOPOLOGY value) { topology = value; }
+
+	const std::shared_ptr<Material>& GetMaterial() const { return material; }
+
+private:
+	std::shared_ptr<Mesh> mesh;
+	std::shared_ptr<Material> material;
+
+	D3D11_PRIMITIVE_TOPOLOGY topology = D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST;
+};

--- a/ProjectArenaDungeon/GameInstance.cpp
+++ b/ProjectArenaDungeon/GameInstance.cpp
@@ -4,6 +4,9 @@
 // Scenes
 #include "Scenes/SceneList.h"
 
+// Utilities
+#include "Utilities/Random.h"
+
 GameInstance::GameInstance() {}
 
 GameInstance::~GameInstance()
@@ -18,7 +21,7 @@ GameInstance::~GameInstance()
 void GameInstance::Init()
 {
 	// TODO: 전역 유틸 초기화
-	// Random::Init();
+	Random::Init();
 
 	// 씬 추가
 	//sceneList.push_back(std::make_shared<Loadout>());

--- a/ProjectArenaDungeon/ProjectArenaDungeon.vcxproj
+++ b/ProjectArenaDungeon/ProjectArenaDungeon.vcxproj
@@ -153,6 +153,7 @@
     <ClCompile Include="Components\CircleCollider.cpp" />
     <ClCompile Include="Components\Collider.cpp" />
     <ClCompile Include="Components\Components.cpp" />
+    <ClCompile Include="Components\MeshRenderer.cpp" />
     <ClCompile Include="Components\RigidBody.cpp" />
     <ClCompile Include="Components\Transform.cpp" />
     <ClCompile Include="GameInstance.cpp" />
@@ -188,6 +189,7 @@
     <ClInclude Include="Components\CircleCollider.h" />
     <ClInclude Include="Components\Collider.h" />
     <ClInclude Include="Components\Component.h" />
+    <ClInclude Include="Components\MeshRenderer.h" />
     <ClInclude Include="Components\RigidBody.h" />
     <ClInclude Include="Components\Transform.h" />
     <ClInclude Include="Config\ConstantValues.h" />

--- a/ProjectArenaDungeon/Resources/Material.cpp
+++ b/ProjectArenaDungeon/Resources/Material.cpp
@@ -25,6 +25,8 @@ Material::Material(std::wstring shaderPath, std::span<const D3D11_INPUT_ELEMENT_
 	frameBuffer->SetFrameData(DirectX::SimpleMath::Vector2(0.0f, 0.0f), DirectX::SimpleMath::Vector2(1.0f, 1.0f));
 }
 
+Material::~Material() = default;
+
 void Material::SetTexture(const std::wstring& path)
 {
 	texture = TEXTURES.LoadTexture(path);

--- a/ProjectArenaDungeon/Resources/Material.h
+++ b/ProjectArenaDungeon/Resources/Material.h
@@ -3,12 +3,12 @@
 #include <string>
 #include <span>
 
-class ColorBuffer;
-class FrameBuffer;
 class InputLayout;
 class VertexShader;
 class PixelShader;
 class Texture;
+class ColorBuffer;
+class FrameBuffer;
 
 // Material
 // - 렌더링에 필요한 ShaderSet(IL/VS/PS)과 Sampler, 텍스처, 상수 버퍼를 묶어 관리
@@ -20,6 +20,7 @@ public:
 	// - shaderPath + layoutDesc로 ShaderSet(IL/VS/PS)을 가져오고,
 	//   기본 Color/Frame 상수 버퍼를 초기화
 	Material(std::wstring shaderPath, std::span<const D3D11_INPUT_ELEMENT_DESC> layoutDesc);
+	~Material();
 
 	// Bind
 	// - InputLayout / VS / PS 바인딩

--- a/ProjectArenaDungeon/Scenes/TestScenes/Scene_TestFeature.cpp
+++ b/ProjectArenaDungeon/Scenes/TestScenes/Scene_TestFeature.cpp
@@ -1,22 +1,72 @@
 #include "pch.h"
 #include "Scene_TestFeature.h"
 
+#include <box2d/box2d.h>
+#include "_Libraries/DirectXTK/SimpleMath.h"
+
+#include "Objects/Object.h"
+
+#include "Components/Transform.h"
+#include "Components/MeshRenderer.h"
+#include "Components/RigidBody.h"
+#include "Components/BoxCollider.h"
+
+#include "Utilities/ObjectFactory.h"
+#include "Utilities/Random.h"
+
+namespace
+{
+	using Vector2 = DirectX::SimpleMath::Vector2;
+	constexpr Vector2 TEST_DEFAULT_OBJECT_SCALE = Vector2(50.0f, 50.0f);
+}
+
 void Scene_TestFeature::Init()
 {
+	testObj = ObjectFactory::CreateColorRect(CENTER, TEST_DEFAULT_OBJECT_SCALE, 0.0f, RED);
+	testObj->AddComponent(std::make_shared<RigidBody>(BodyType::Dynamic));
+	testObj->AddComponent(std::make_shared<BoxCollider>());
+	AddObject(testObj);
 
+	auto transform = testObj->GetTransform();
+	if (transform)
+	{
+		std::cout << "valid transform" << '\n';
+	}
+
+	auto material = testObj->GetComponent<MeshRenderer>("MeshRenderer")->GetMaterial();
+	if (material)
+	{
+		std::cout << "valid material" << '\n';
+	}
+
+	auto body = testObj->GetComponent<RigidBody>("RigidBody");
+	if (b2Body_IsValid(body->GetBodyId()))
+	{
+		std::cout << "valid rigid body" << '\n';
+	}
+
+	auto collider = testObj->GetComponent<BoxCollider>("BoxCollider");
+	if (b2Shape_IsValid(collider->GetShapeId()))
+	{
+		std::cout << "valid collider" << '\n';
+	}
 }
 
 void Scene_TestFeature::Destroy()
 {
+	testObj = nullptr;
 
+	objects.clear();
 }
 
 void Scene_TestFeature::Update()
 {
+	std::cout << Random::Range(1, 10) << '\n';
 
+	__super::Update();
 }
 
 void Scene_TestFeature::Render()
 {
-
+	__super::Render();
 }

--- a/ProjectArenaDungeon/Scenes/TestScenes/Scene_TestFeature.h
+++ b/ProjectArenaDungeon/Scenes/TestScenes/Scene_TestFeature.h
@@ -1,6 +1,8 @@
 #pragma once
 #include "Scenes/Scene.h"
 
+class Object;
+
 class Scene_TestFeature : public Scene
 {
 public:
@@ -11,5 +13,5 @@ public:
 	void Render() override;
 
 private:
-
+	std::shared_ptr<Object> testObj;
 };

--- a/ProjectArenaDungeon/Utilities/ObjectFactory.cpp
+++ b/ProjectArenaDungeon/Utilities/ObjectFactory.cpp
@@ -35,7 +35,7 @@ void AttachMeshAndMaterial(
 	const std::wstring& texturePath = L""
 )
 {
-	auto renderer = make_shared<MeshRenderer>();
+	auto renderer = std::make_shared<MeshRenderer>();
 
 	renderer->SetMesh(mesh);
 	renderer->SetTopology(topology);

--- a/ProjectArenaDungeon/_Shaders/Vertex.hlsl
+++ b/ProjectArenaDungeon/_Shaders/Vertex.hlsl
@@ -1,0 +1,41 @@
+struct VertexInput
+{
+    float4 position : POSITION0;
+};
+
+struct PixelInput
+{
+    float4 position : SV_POSITION0;
+};
+
+cbuffer World : register(b0)
+{
+    matrix _world;
+}
+
+cbuffer ViewPorjection : register(b1)
+{
+    matrix _view;
+    matrix _proj;
+}
+
+PixelInput VS(VertexInput input)
+{
+    PixelInput output;
+    
+    output.position = mul(input.position, _world);
+    output.position = mul(output.position, _view);
+    output.position = mul(output.position, _proj);
+
+    return output;
+}
+
+cbuffer ColorBuffer : register(b2)
+{
+    float4 _color;
+}
+
+float4 PS(PixelInput input) : SV_Target0
+{
+    return _color;
+}

--- a/ProjectArenaDungeon/pch.h
+++ b/ProjectArenaDungeon/pch.h
@@ -105,3 +105,13 @@ static CLASS_NAME& GetInstance()								\
 #define SHADERS ShaderManager::GetInstance()
 #define TEXTURES TextureManager::GetInstance()
 #define PHYSICS PhysicsManager::GetInstance()
+
+// ColorMacros
+#define RED Color(1, 0, 0, 1)
+#define GREEN Color(0, 1, 0, 1)
+#define BLUE Color(0, 0, 1, 1)
+#define YELLOW Color(1, 1, 0, 1)
+#define MAGENTA Color(1, 0, 1, 1)
+#define CYAN Color(0, 1, 1, 1)
+#define WHITE Color(1, 1, 1, 1)
+#define BLACK Color(0, 0, 0, 1)


### PR DESCRIPTION
## Overview
MeshRenderer 컴포넌트를 추가하여 Mesh/Material 기반 렌더링 구조를 구축하고,
테스트 씬을 통해 렌더링 및 컴포넌트 연결 상태를 확인합니다.

---

## Changes

### MeshRenderer 컴포넌트 추가
- Mesh / Material 바인딩 후 DrawIndexed 호출 구현
- D3D11_PRIMITIVE_TOPOLOGY 설정 인터페이스 추가 (기본값 TRIANGLELIST)
- 현재 구조에서는 MeshRenderer가 직접 DrawCall 수행
- 이후 Instancing / Batching 도입 시 RenderSystem 구조로 이관 예정

### Material 관련 수정 (fix)
- ColorBuffer 전방 선언 + unique_ptr 조합으로 인한 정의되지 않은 형식 오류 수정
- ObjectFactory에서 std:: 네임스페이스 누락 수정

### 색상 매크로 추가
- 미리 컴파일된 헤더(pch)에 색상 매크로 추가
- 테스트 및 생성 코드에서 색상 사용 편의성 확보

### Vertex.hlsl
- 단색 렌더링용 셰이더 추가

### GameInstance
- Random 유틸 동작 확인을 위한 초기화 코드 추가

### Scene_TestFeature
- 테스트 오브젝트 생성 (ColorRect)
- RigidBody / BoxCollider 컴포넌트 부착
- Transform / Material / RigidBody / Collider 유효성 확인용 디버그 콘솔 출력 추가
- Random 유틸 동작 확인용 콘솔 출력 추가

---

## Purpose

- MeshRenderer를 통해 실제 화면 렌더링 경로를 확립
- ObjectFactory → MeshRenderer → Material → Shader 파이프라인 검증
- 컴포넌트 연결 및 물리/렌더 결합 구조 1차 검증
- 이후 RenderSystem 구조 확장 및 Instancing 대비 기반 마련

---

## How to Test

1. 디버그 모드로 빌드
2. Scene_TestFeature 실행 확인
3. 콘솔 창에서 다음 항목 출력 여부 확인 (Transform / Material(MeshRenderer) / RigidBody / Collider)
4. 컴파일 에러 및 경고 여부 확인

---

## Notes

- 현재는 MeshRenderer가 직접 DrawCall을 수행하는 구조
- RenderSystem 도입 시 DrawCall 요청 방식으로 구조 변경 예정
- 테스트 씬은 기능 검증 목적으로 작성