### PR TITLE
feat: Camera 오브젝트 추가

### DIFF
--- a/ProjectArenaDungeon/Objects/Camera.cpp
+++ b/ProjectArenaDungeon/Objects/Camera.cpp
@@ -1,0 +1,107 @@
+#include "pch.h"
+#include "Objects/Camera.h"
+
+#include <cmath>
+
+#include "Config/ConstantValues.h"
+#include "Components/Transform.h"
+#include "Renders/ConstantBuffers/GlobalBuffers.h"
+
+Camera::Camera()
+	: Object("MainCamera")
+{
+	vpBuffer = std::make_unique<ViewProjectionBuffer>();
+
+	proj = DirectX::XMMatrixOrthographicOffCenterLH(0, gWinWidth, 0, gWinHeight, -1.0f, 1.0f);
+
+	vpBuffer->SetProjectionMatrix(proj);
+
+	// NOTE:
+	// - 줌은 scale.x를 기준으로 사용(카메라는 균일 스케일만 허용)
+	transform->SetScale({ 1.0f, 1.0f });
+}
+
+void Camera::Update()
+{
+	__super::Update();
+
+	const DirectX::SimpleMath::Vector2 pos = transform->GetPosition();
+	const float rot = transform->GetRotationRadian();
+	const float zoom = transform->GetScale().x;
+
+	// NOTE: float 비교는 epsilon 기반으로 처리한다.
+	const bool samePos = (DirectX::SimpleMath::Vector2::DistanceSquared(pos, lastPos) <= epsilonSq);
+	const bool sameRot = (std::fabs(rot - lastRot) <= epsilon);
+	const bool sameZoom = (std::fabs(zoom - lastZoom) <= epsilon);
+
+	if (samePos && sameRot && sameZoom)
+		return;
+
+	lastPos = pos;
+	lastRot = rot;
+	lastZoom = zoom;
+
+	RebuildMatrices();
+
+	vpBuffer->SetViewMatrix(view);
+	vpBuffer->Update();
+}
+
+void Camera::RebuildMatrices()
+{
+	const DirectX::SimpleMath::Vector2 pos = transform->GetPosition();
+	const float rot = transform->GetRotationRadian();
+	const float zoom = transform->GetScale().x;
+
+	// NOTE:
+	// - 카메라는 월드의 반대 변환을 적용
+	// - (카메라가 오른쪽으로 이동) == (월드가 왼쪽으로 이동)
+	const DirectX::SimpleMath::Matrix T = DirectX::XMMatrixTranslation(-pos.x, -pos.y, 0.0f);
+	const DirectX::SimpleMath::Matrix R = DirectX::XMMatrixRotationZ(-rot);
+	const DirectX::SimpleMath::Matrix S = DirectX::XMMatrixScaling(zoom, zoom, 1.0f);
+
+	view = T * R * S;
+}
+
+void Camera::Bind() const
+{
+	// NOTE:
+	// - HLSL: cbuffer ViewProjection : register(b1)
+	vpBuffer->BindVS(1);
+}
+
+void Camera::Move(DirectX::SimpleMath::Vector2 delta)
+{
+	transform->Move(delta);
+}
+
+void Camera::SetZoom(float value)
+{
+	// NOTE: 0 이하 방지
+	if (value < epsilon)
+		value = epsilon;
+
+	transform->SetScale({ value, value });
+}
+
+float Camera::GetZoom() const
+{
+	return transform->GetScale().x;
+}
+
+DirectX::SimpleMath::Vector2 Camera::ScreenToWorld(DirectX::SimpleMath::Vector2 screenPos) const
+{
+	// NOTE:
+	// - 현재 버전은 "카메라 회전 미지원" 변환이다.
+	// - 회전까지 포함하려면 view의 역행렬 기반 변환으로 확장한다.
+	const float zoom = GetZoom();
+	const DirectX::SimpleMath::Vector2 pos = transform->GetPosition();
+	return (screenPos / zoom) + pos;
+}
+
+DirectX::SimpleMath::Vector2 Camera::WorldToScreen(DirectX::SimpleMath::Vector2 worldPos) const
+{
+	const float zoom = GetZoom();
+	const DirectX::SimpleMath::Vector2 pos = transform->GetPosition();
+	return (worldPos - pos) * zoom;
+}

--- a/ProjectArenaDungeon/Objects/Camera.h
+++ b/ProjectArenaDungeon/Objects/Camera.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "Objects/Object.h"
+
+class ViewProjectionBuffer;
+
+// Camera
+// - 뷰/프로젝션 행렬을 계산하고 셰이더 상수 버퍼로 바인딩하는 오브젝트
+// - 카메라 이동/줌 기능
+class Camera final : public Object
+{
+public:
+	Camera();
+
+	void Update() override;
+
+	// Bind
+	// - 현재 view/projection을 VS 상수 버퍼 슬롯(b1)에 바인딩한다.
+	void Bind() const;
+
+	// 카메라 이동/줌
+	void Move(DirectX::SimpleMath::Vector2 delta);
+	void SetZoom(float value);
+	float GetZoom() const;
+
+	// 좌표 변환
+	DirectX::SimpleMath::Vector2 ScreenToWorld(DirectX::SimpleMath::Vector2 screenPos) const;
+	DirectX::SimpleMath::Vector2 WorldToScreen(DirectX::SimpleMath::Vector2 worldPos) const;
+
+	DirectX::SimpleMath::Matrix GetView() const { return view; }
+	DirectX::SimpleMath::Matrix GetProj() const { return proj; }
+
+private:
+	// RebuildMatrices
+	// - Transform 값이 변했을 때 view 행렬을 갱신
+	void RebuildMatrices();
+
+private:
+	DirectX::SimpleMath::Matrix view = DirectX::SimpleMath::Matrix::Identity;
+	DirectX::SimpleMath::Matrix proj = DirectX::SimpleMath::Matrix::Identity;
+
+	std::unique_ptr<ViewProjectionBuffer> vpBuffer;
+
+	// NOTE:
+	// - 값 변경 시에만 view 재계산을 하기 위한 캐시
+	DirectX::SimpleMath::Vector2 lastPos = { -9999.0f, -9999.0f };
+	float lastRot = -9999.0f;
+	float lastZoom = -9999.0f;
+};

--- a/ProjectArenaDungeon/ProjectArenaDungeon.vcxproj
+++ b/ProjectArenaDungeon/ProjectArenaDungeon.vcxproj
@@ -164,6 +164,7 @@
     <ClCompile Include="Managers\ShaderManager.cpp" />
     <ClCompile Include="Managers\TextureManager.cpp" />
     <ClCompile Include="Managers\TimeManager.cpp" />
+    <ClCompile Include="Objects\Camera.cpp" />
     <ClCompile Include="Objects\Object.cpp" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
@@ -200,6 +201,7 @@
     <ClInclude Include="Managers\ShaderManager.h" />
     <ClInclude Include="Managers\TextureManager.h" />
     <ClInclude Include="Managers\TimeManager.h" />
+    <ClInclude Include="Objects\Camera.h" />
     <ClInclude Include="Objects\Object.h" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="Renders\ConstantBuffers\ConstantBuffer.h" />

--- a/ProjectArenaDungeon/ProjectArenaDungeon.vcxproj.filters
+++ b/ProjectArenaDungeon/ProjectArenaDungeon.vcxproj.filters
@@ -124,6 +124,12 @@
     <ClCompile Include="Utilities\Random.cpp">
       <Filter>Utilities</Filter>
     </ClCompile>
+    <ClCompile Include="Components\MeshRenderer.cpp">
+      <Filter>Components</Filter>
+    </ClCompile>
+    <ClCompile Include="Objects\Camera.cpp">
+      <Filter>Objects</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />
@@ -228,6 +234,12 @@
     </ClInclude>
     <ClInclude Include="Utilities\Random.h">
       <Filter>Utilities</Filter>
+    </ClInclude>
+    <ClInclude Include="Components\MeshRenderer.h">
+      <Filter>Components</Filter>
+    </ClInclude>
+    <ClInclude Include="Objects\Camera.h">
+      <Filter>Objects</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Overview
Object를 상속받는 Camera 오브젝트를 추가하여 View / Projection 행렬을 관리하고,
ViewProjectionBuffer를 통해 셰이더 VS(b1)에 카메라 상태를 전달하는 구조를 구축합니다.

---

## Changes

- Object를 상속받는 Camera 클래스 구현
- Transform 기반 위치 / 회전 / 줌 값에 따라 View 행렬 계산
- Orthographic Projection 설정
- ViewProjectionBuffer를 통해 VS(b1) 슬롯에 바인딩
- 값 변경 시에만 행렬 재계산하도록 최적화 (Transform 값 비교 기반)
- 카메라 이동(Move), 줌(SetZoom) 인터페이스 추가
- ScreenToWorld / WorldToScreen 좌표 변환 함수 추가
- DrawCall은 수행하지 않고 Bind()에서 상수 버퍼만 바인딩

---

## Purpose

- View / Projection 행렬을 오브젝트 기반으로 관리
- 카메라 이동 확장을 위한 기반 마련
- 월드 좌표계와 화면 좌표계 변환 로직 처리
- PlayerController 및 전투 로직 구현 전, 시점 제어 구조 확보

---

## How to Test

1. 디버그 모드로 빌드
2. Camera 오브젝트가 정상 생성되는지 확인
3. 화면 출력이 정상적으로 이루어지는지 확인
4. 컴파일 에러 및 경고 여부 확인

---

## Notes

- 단일 Camera 기준 구조
- 회전을 포함한 ScreenToWorld 변환은 단순 2D 기준 구현